### PR TITLE
ci: add reusable workflows

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @aws-deadline/Developers

--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -1,6 +1,15 @@
-*Issue #, if available:*
+### What was the problem/requirement? (What/Why)
 
-*Description of changes:*
+### What was the solution? (How)
 
+### What is the impact of this change?
 
-By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
+### How was this change tested?
+
+### Was this change documented?
+
+### Is this a breaking change?
+
+----
+
+*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

--- a/scripts/get_latest_changelog.py
+++ b/scripts/get_latest_changelog.py
@@ -1,0 +1,39 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+"""
+This script gets the changelog notes for the latest version of this package. It makes the following assumptions
+1. A file called CHANGELOG.md is in the current directory that has the changelog
+2. The changelog file is formatted in a way such that level 2 headers are:
+    a. The only indication of the beginning of a version's changelog notes.
+    b. Always begin with `## `
+3. The changelog file contains the newest version's changelog notes at the top of the file.
+
+Example CHANGELOG.md:
+```
+## 1.0.0 (2024-02-06)
+
+### BREAKING CHANGES
+* **api**: rename all APIs
+
+## 0.1.0 (2024-02-06)
+
+### Features
+* **api**: add new api
+```
+
+Running this script on the above CHANGELOG.md should return the following contents:
+```
+## 1.0.0 (2024-02-06)
+
+### BREAKING CHANGES
+* **api**: rename all APIs
+
+```
+"""
+import re
+
+h2 = r"^##\s.*$"
+with open("CHANGELOG.md") as f:
+    contents = f.read()
+matches = re.findall(h2, contents, re.MULTILINE)
+changelog = contents[: contents.find(matches[1]) - 1] if len(matches) > 1 else contents
+print(changelog)

--- a/workflows/reusable_bump.yml
+++ b/workflows/reusable_bump.yml
@@ -1,0 +1,77 @@
+
+name: "Bump"
+
+on:
+  workflow_call:
+    inputs:
+      force_version_bump:
+        required: false
+        default: ""
+        type: string        
+
+jobs:
+  Bump:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: mainline
+          fetch-depth: 0
+          token: ${{ secrets.CI_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: ConfigureGit
+        run: |
+          git config --local user.email ${{secrets.EMAIL}}
+          git config --local user.name ${{secrets.USER}}
+
+      - name: Bump
+        run: |
+          BUMP_ARGS=""
+          if [[ "${{ inputs.force_version_bump }}" != "" ]]; then
+            BUMP_ARGS="$BUMP_ARGS --${{ inputs.force_version_bump }}"
+          fi
+
+          # Backup actual changelog to preserve its contents
+          touch CHANGELOG.md
+          cp CHANGELOG.md CHANGELOG.bak.md
+
+          # Run semantic-release to generate new changelog
+          pip install --upgrade hatch
+          hatch env create release
+          hatch run release:deps
+          NEXT_SEMVER=$(hatch run release:bump $BUMP_ARGS)
+
+          # Grab the new version's changelog and prepend it to the original changelog contents
+          python .github/scripts/get_latest_changelog.py > NEW_LOG.md
+          cat NEW_LOG.md CHANGELOG.bak.md > CHANGELOG.md
+          rm NEW_LOG.md
+
+          git checkout -b bump/$NEXT_SEMVER
+          git add CHANGELOG.md
+          git commit -sm "chore(release): $NEXT_SEMVER"
+
+          echo "NEXT_SEMVER=$NEXT_SEMVER" >> $GITHUB_ENV
+          {
+            echo 'RELEASE_NOTES<<EOF'
+            python .github/scripts/get_latest_changelog.py
+            echo EOF
+          } >> $GITHUB_ENV
+
+      - name: PushPR
+        env:
+          GH_TOKEN: ${{ secrets.CI_TOKEN }}
+        run: |
+          git push -u origin bump/$NEXT_SEMVER
+
+          # Needs "Allow GitHub Actions to create and approve pull requests" under Settings > Actions
+          gh pr create --base mainline --title "chore(release): $NEXT_SEMVER" --body "$RELEASE_NOTES"

--- a/workflows/reusable_canary.yml
+++ b/workflows/reusable_canary.yml
@@ -1,0 +1,68 @@
+name: Canary
+
+on:
+    workflow_call:
+      inputs:
+        repository:
+          required: true
+          type: string
+        branch:
+            required: true
+            type: string
+        environment:
+            required: true
+            type: string
+
+jobs:
+  Canary:
+    name: Canary
+    runs-on: ubuntu-latest
+    environment: ${{inputs.environment}}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        if: ${{inputs.branch == 'mainline'}}
+        with:
+          ref: mainline
+      
+      - uses: actions/checkout@v4
+        if: ${{inputs.branch == 'release'}}
+        with:
+          ref: release
+          
+      - name: Configure AWS credentials for release
+        if: ${{inputs.branch == 'release'}}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_CANARY_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+       
+      - name: Configure AWS credentials for mainline
+        if: ${{inputs.branch == 'mainline'}}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_CANARY_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+        
+      - name: Run Canary for Mainline
+        if: ${{inputs.branch == 'mainline'}}
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: ${{inputs.repository}}-${{inputs.branch}}-Canary
+          hide-cloudwatch-logs: true
+          env-vars-for-codebuild: |
+              TEST_TYPE
+        env:
+          TEST_TYPE: WHEEL
+
+      - name: Run Canary for Release
+        if: ${{inputs.branch == 'release'}}
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: ${{inputs.repository}}-${{inputs.branch}}-Canary
+          source-version-override: refs/heads/release
+          hide-cloudwatch-logs: true

--- a/workflows/reusable_integration_test.yml
+++ b/workflows/reusable_integration_test.yml
@@ -1,0 +1,59 @@
+name: "Integration Tests"
+
+on:
+    workflow_call:
+      inputs:
+        repository:
+          required: true
+          type: string
+        branch:
+            required: true
+            type: string
+        environment:
+            required: true
+            type: string
+
+jobs:
+  IntegrationTests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    environment: ${{inputs.environment}}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        if: ${{inputs.branch == 'mainline'}}
+        with:
+          ref: mainline
+      
+      - uses: actions/checkout@v4
+        if: ${{inputs.branch == 'release'}}
+        with:
+          ref: release
+          
+      - name: Configure AWS credentials for release
+        if: ${{inputs.branch == 'release'}}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_INTEG_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+       
+      - name: Configure AWS credentials for mainline
+        if: ${{inputs.branch == 'mainline'}}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_INTEG_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+        
+      - name: Run CodeBuild for Mainline
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: ${{inputs.repository}}-${{inputs.branch}}-IntegTest
+          hide-cloudwatch-logs: true
+          env-vars-for-codebuild: |
+              TEST_TYPE
+        env:
+          TEST_TYPE: WHEEL

--- a/workflows/reusable_publish.yml
+++ b/workflows/reusable_publish.yml
@@ -1,0 +1,191 @@
+name: "Publish"
+
+on:
+  workflow_call:
+
+jobs:
+  VerifyCommit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: VerifyAuthor
+        run: |
+          EXPECTED_AUTHOR=${{secrets.EMAIL}}
+          AUTHOR=$(git show -s --format='%ae' HEAD)
+          if [[ $AUTHOR != $EXPECTED_AUTHOR ]]; then
+            echo "ERROR: Expected author email to be '$EXPECTED_AUTHOR', but got '$AUTHOR'. Aborting release."
+            exit 1
+          else
+            echo "Verified author email ($AUTHOR) is as expected ($EXPECTED_AUTHOR)"
+          fi
+
+  Release:
+    needs: VerifyCommit
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: release
+          fetch-depth: 0
+          token: ${{ secrets.CI_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: ConfigureGit
+        run: |
+          git config --local user.email ${{ secrets.EMAIL }}
+          git config --local user.name ${{ secrets.USER }}
+      
+      - name: MergePushRelease
+        run: |
+          git merge --ff-only origin/mainline -v
+          git push origin release    
+
+      - name: PrepRelease
+        id: prep-release
+        run: |
+          COMMIT_TITLE=$(git show -s --format='%s' HEAD)
+          NEXT_SEMVER=$(python -c 'import sys, re; print(re.match(r"chore\(release\): ([0-9]+\.[0-9]+\.[0-9]+).*", sys.argv[1]).group(1))' "$COMMIT_TITLE")
+
+          # The format of the tag must match the pattern in pyproject.toml -> tool.semantic_release.tag_format
+          TAG="$NEXT_SEMVER"
+
+          git tag -a $TAG -m "Release $TAG"
+
+          echo "TAG=$TAG" >> $GITHUB_ENV
+          echo "NEXT_SEMVER=$NEXT_SEMVER" >> $GITHUB_ENV
+          {
+            echo 'RELEASE_NOTES<<EOF'
+            python .github/scripts/get_latest_changelog.py
+            echo EOF
+          } >> $GITHUB_ENV
+
+      # Tag must be made before building so the generated _version.py files have the correct version
+      - name: Build
+        run: |
+          pip install --upgrade hatch
+          hatch -v build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PGP_KEY_SECRET_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+
+      - name: Import PGP Key
+        run: |
+          export SECRET_STRING="$(aws secretsmanager get-secret-value --secret-id ${{ secrets.AWS_PGP_KEY_SECRET }} --query 'SecretString')"
+          printenv SECRET_STRING | jq -r '. | fromjson | .PrivateKey' | gpg --batch --pinentry-mode loopback --import --armor
+
+          PGP_KEY_PASSPHRASE=$(printenv SECRET_STRING | jq -r '. | fromjson | .Passphrase')
+          echo "::add-mask::$PGP_KEY_PASSPHRASE"
+          echo "PGP_KEY_PASSPHRASE=$PGP_KEY_PASSPHRASE" >> $GITHUB_ENV
+
+      - name: Sign
+        run: |
+          for file in dist/*; do
+             printenv PGP_KEY_PASSPHRASE | gpg --batch --pinentry-mode loopback --local-user "AWS Deadline Cloud" --passphrase-fd 0 --output $file.sig --detach-sign $file
+             echo "Created signature file for $file"
+          done
+
+      - name: PushRelease
+        env:
+          GH_TOKEN: ${{ secrets.CI_TOKEN }}
+        run: |
+          git push origin $TAG
+          gh release create $TAG dist/* --notes "$RELEASE_NOTES"
+
+  PublishToInternal:
+    needs: Release
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_PUBLISH_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+
+      - name: Run CodeBuild
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: ${{ github.event.repository.name }}-Publish
+          hide-cloudwatch-logs: true
+  
+  PublishToRepository:
+    needs: PublishToInternal
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      CODEARTIFACT_REGION: "us-west-2"
+      CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
+      CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
+      CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
+      CUSTOMER_DOMAIN: ${{ secrets.CUSTOMER_DOMAIN }}
+      CUSTOMER_REPOSITORY: ${{ secrets.CUSTOMER_REPOSITORY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: release
+          fetch-depth: 0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade hatch
+          pip install --upgrade twine
+
+      - name: Build
+        run: hatch -v build
+
+      - name: Publish to Repository
+        run: |
+          export TWINE_USERNAME=aws
+          export TWINE_PASSWORD=`aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text`
+          export TWINE_REPOSITORY_URL=`aws codeartifact get-repository-endpoint --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --repository ${{ secrets.CODEARTIFACT_REPOSITORY }} --format pypi --query repositoryEndpoint --output text`
+          twine upload dist/*
+
+      - name: Publish to Customer Repository
+        run: |
+          export TWINE_USERNAME=aws
+          export TWINE_PASSWORD=`aws codeartifact get-authorization-token --domain ${{ secrets.CUSTOMER_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text`
+          export TWINE_REPOSITORY_URL=`aws codeartifact get-repository-endpoint --domain ${{ secrets.CUSTOMER_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --repository ${{ secrets.CUSTOMER_REPOSITORY }} --format pypi --query repositoryEndpoint --output text`
+          twine upload dist/*
+
+      # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/workflows/reusable_python_build.yml
+++ b/workflows/reusable_python_build.yml
@@ -1,0 +1,58 @@
+name: Python Build
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        required: false
+        type: string
+      commit:
+        required: false
+        type: string
+      python-version:
+        required: true
+        type: string
+      os:
+        required: true
+        type: string
+
+jobs:
+  Python:
+    runs-on: ${{ inputs.os }}
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      PYTHON: ${{ inputs.python-version }}
+    steps:
+    - uses: actions/checkout@v4
+      if: ${{ !inputs.branch && !inputs.commit }}
+
+    - uses: actions/checkout@v4
+      if: ${{ inputs.branch }}
+      with:
+        ref: ${{ inputs.branch }}
+        fetch-depth: 0
+
+    - uses: actions/checkout@v4
+      if: ${{ inputs.commit }}
+      with:
+        ref: ${{ inputs.commit }}
+
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install Hatch
+      run: |
+        pip install --upgrade hatch
+
+    - name: Run Linting
+      run: hatch -v run lint
+
+    - name: Run Build
+      run: hatch -v build
+
+    - name: Run Tests
+      run: hatch run test


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Currently we have workflows with the same functional code replicated across 14+ repositories. When making a change to a repository we have to replicate the change this many times.

### What was the solution? (How)
To lower the maintenance cost of workflow changes we are using reuable workflows. This allows us to store the functional code in a single location and then have each repository reference the reusable workflows

Example:
```
name: "Release: Publish"
run-name: "Release: ${{ github.event.head_commit.message }}"

on:
  push:
    branches:
      - mainline
    paths:
      - CHANGELOG.md

concurrency:
  group: release

jobs:
  Publish:
    name: Publish Release
    uses: aws-deadline/.github/reusable_publish.yml@mainline
    secrets: inherit
```

Also added a default PR template and CODEOWNERS

### What is the impact of this change?
We can now work with workflows from a single location most of the time to make changes.

### How was this change tested?
Tested in a developer account. Continued testing to will be done after merge.

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*