### PR TITLE
ci: change python build job name

### DIFF
--- a/.github/workflows/reusable_python_build.yml
+++ b/.github/workflows/reusable_python_build.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   Python:
-    name: ${{ inputs.os }}, python ${{ inputs.python-version }}
+    name: Unit Tests
     runs-on: ${{ inputs.os }}
     permissions:
       contents: read


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Currently in repositories, the status check workflow names repetitive, they show up as:
```
Code Quality / Python (ubuntu-latest, 3.9) / ubuntu-latest, python 3.9 (pull_request)
```

I'd like to change it to:
```
Code Quality / Python (ubuntu-latest, 3.9) / Unit Tests (pull_request)
```


### What was the solution? (How)
Change the job name

### What is the impact of this change?
better naming in the status checks section of the repository

### How was this change tested?
n/a

### Was this change documented?
no

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*