### PR TITLE
revert: ci: change python build job name

### DIFF
--- a/.github/workflows/reusable_python_build.yml
+++ b/.github/workflows/reusable_python_build.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   Python:
-    name: Unit Tests
+    name: ${{ inputs.os }}, python ${{ inputs.python-version }}
     runs-on: ${{ inputs.os }}
     permissions:
       contents: read


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
This commit needs to be reverted because it causes naming issues in workflows that call the code quality workflow

see unit tests here: https://github.com/OpenJobDescription/openjd-model-for-python/actions/runs/8791125853

we are unable to determine os and python version at a glance.

### What was the solution? (How)
reverts job name change

### What is the impact of this change?
reverts name change

### How was this change tested?
development github account

### Was this change documented?
no

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*