### PR TITLE
chore: add org wide issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,94 @@
+name: "\U0001F41B Bug Report"
+description: Report a bug
+title: "Bug: TITLE"
+labels: ["bug"]
+body:
+  - type: textarea
+    id: describe_behaviour
+    attributes:
+      label: Describe Behaviour
+      description: What is the problem? A clear and concise description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behaviour
+    attributes:
+      label: Expected Behaviour
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_behaviour
+    attributes:
+      label: Current Behaviour
+      description: |
+        What actually happened?
+        
+        Please include full errors, uncaught exceptions, stack traces, and relevant logs.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction_steps
+    attributes:
+      label: Reproduction Steps
+      description: |
+        Provide a self-contained, concise snippet of code that can be used to reproduce the issue.
+        For more complex issues provide a repo with the smallest sample that reproduces the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: possible_solution
+    attributes:
+      label: Possible Solution
+      description: |
+        Suggest a fix/reason for the bug
+    validations:
+      required: false
+
+  - type: input
+    id: package-version
+    attributes:
+      label: Package Version
+      description: E.g. deadline-cloud (0.48.1) | deadline-worker-agent (0.27.1)
+    validations:
+      required: true
+
+  - type: input
+    id: language-version
+    attributes:
+      label: Language Version
+      description: E.g. Python (3.11.4)
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: E.g. pip list
+    validations:
+      required: false
+
+  - type: input
+    id: operating-system
+    attributes:
+      label: Operating System
+      description: Linux, Windows, MacOS
+    validations:
+      required: true
+  
+  - type: textarea
+    id: other
+    attributes:
+      label: Other information
+      description: |
+        e.g. dcc/third-party integration application versions (e.g maya, nuke, blender), detailed explanation, stacktraces, related issues, suggestions how to fix, links for us to have context, eg. associated pull-request, stackoverflow, etc
+    validations:
+      required: false
+
+
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/doc.yml
+++ b/.github/ISSUE_TEMPLATE/doc.yml
@@ -1,0 +1,13 @@
+
+name: "📕 Documentation Issue"
+description: Issue in the documentation
+title: "Docs: TITLE"
+labels: ["documenation"]
+body:
+  - type: textarea
+    id: documentation_issue
+    attributes:
+      label: Documentation Issue
+      description: Describe the issue
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,17 @@
+name: "\U0001F680 Feature Request"
+description: Request a new feature
+title: "Feature request: TITLE"
+labels: ["feature"]
+body:
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use Case
+    validations:
+      required: true
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed Solution
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -1,0 +1,17 @@
+name: "🛠️ Maintenance"
+description: Some type of improvement
+title: "Maintenance: TITLE"
+labels: ["feature"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solution
+    validations:
+      required: true


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want to have org wide issue templates

### What was the solution? (How)
Add the templates to .github repository

### What is the impact of this change?
Will enable org wide templates

### How was this change tested?
n/a

### Was this change documented?
n/a

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*