### PR TITLE
ci!: add e2e reusable workflow

### DIFF
--- a/.github/workflows/reusable_canary.yml
+++ b/.github/workflows/reusable_canary.yml
@@ -12,6 +12,9 @@ on:
       environment:
         required: true
         type: string
+      os:
+        required: true
+        type: string
 
 jobs:
   Canary:
@@ -48,7 +51,7 @@ jobs:
         if: ${{inputs.branch == 'mainline'}}
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
-          project-name: ${{inputs.repository}}-${{inputs.branch}}-Canary
+          project-name: ${{inputs.repository}}-${{inputs.branch}}-${{inputs.os}}-canary
           hide-cloudwatch-logs: true
           env-vars-for-codebuild: |
               TEST_TYPE
@@ -59,6 +62,6 @@ jobs:
         if: ${{inputs.branch == 'release'}}
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
-          project-name: ${{inputs.repository}}-${{inputs.branch}}-Canary
+          project-name: ${{inputs.repository}}-${{inputs.branch}}-${{inputs.os}}-canary
           source-version-override: refs/heads/release
           hide-cloudwatch-logs: true

--- a/.github/workflows/reusable_e2e_test.yml
+++ b/.github/workflows/reusable_e2e_test.yml
@@ -1,4 +1,4 @@
-name: "Integration Tests"
+name: "E2E Tests"
 
 on:
   workflow_call:
@@ -17,9 +17,9 @@ on:
         type: string
 
 jobs:
-  IntegrationTests:
+  E2ETests:
     if: (github.repository == 'aws-deadline/${{inputs.repository}}')
-    name: Integration Tests
+    name: E2E Tests
     runs-on: ubuntu-latest
     environment: ${{inputs.environment}}
     permissions:
@@ -27,7 +27,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-        if: ${{inputs.branch == 'mainline' || inputs.branch == 'release'}}
         with:
           ref: ${{inputs.branch}}
       
@@ -35,7 +34,7 @@ jobs:
         if: ${{inputs.branch == 'release'}}
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_INTEG_ROLE }}
+          role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_E2E_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
        
@@ -43,14 +42,14 @@ jobs:
         if: ${{inputs.branch == 'mainline'}}
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_INTEG_ROLE }}
+          role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_E2E_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
         
-      - name: Run Integration Tests
+      - name: Run E2E Tests
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
-          project-name: ${{inputs.repository}}-${{inputs.branch}}-${{inputs.os}}-integ
+          project-name: ${{inputs.repository}}-${{inputs.branch}}-${{inputs.os}}-e2e
           hide-cloudwatch-logs: true
           env-vars-for-codebuild: |
               TEST_TYPE


### PR DESCRIPTION
# DO NOT MERGE YET

### What was the problem/requirement? (What/Why)
1. Need to add a reusable workflow for e2e testing
2. Add operating system param to integ and canary workflows to support running tests on different operating systems.
3. Canary and Integ project names have been changed, need to be adjusted.

### What was the solution? (How)
1. Add the workflow for E2E tests
2. Add an os param and to differentiate project names from different os test runs.
3. Updated names

### What is the impact of this change?
Adds e2e workflows to run e2e tests

### How was this change tested?
n/a - will need to be tested once merged.

### Was this change documented?
no

### Is this a breaking change?
Yes. Any workflows using integ and canary workflows will need to be updated to pass the operating system.

Currently this includes:
* [deadline-cloud-worker-agent](https://github.com/aws-deadline/deadline-cloud-worker-agent)
* [deadline-cloud](https://github.com/aws-deadline/deadline-cloud)

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*