### PR TITLE
ci: add os environment variable for test workflows

### DIFF
--- a/.github/workflows/reusable_canary.yml
+++ b/.github/workflows/reusable_canary.yml
@@ -55,8 +55,10 @@ jobs:
           hide-cloudwatch-logs: true
           env-vars-for-codebuild: |
               TEST_TYPE
+              OPERATING_SYSTEM
         env:
           TEST_TYPE: WHEEL
+          OPERATING_SYSTEM: ${{inputs.os}}
 
       - name: Run Canary for Release
         if: ${{inputs.branch == 'release'}}

--- a/.github/workflows/reusable_e2e_test.yml
+++ b/.github/workflows/reusable_e2e_test.yml
@@ -52,6 +52,8 @@ jobs:
           project-name: ${{inputs.repository}}-${{inputs.branch}}-${{inputs.os}}-e2e
           hide-cloudwatch-logs: true
           env-vars-for-codebuild: |
-              TEST_TYPE
+              TEST_TYPE,
+              OPERATING_SYSTEM
         env:
           TEST_TYPE: WHEEL
+          OPERATING_SYSTEM: ${{inputs.os}}

--- a/.github/workflows/reusable_integration_test.yml
+++ b/.github/workflows/reusable_integration_test.yml
@@ -53,6 +53,8 @@ jobs:
           project-name: ${{inputs.repository}}-${{inputs.branch}}-${{inputs.os}}-integ
           hide-cloudwatch-logs: true
           env-vars-for-codebuild: |
-              TEST_TYPE
+              TEST_TYPE,
+              OPERATING_SYSTEM
         env:
           TEST_TYPE: WHEEL
+          OPERATING_SYSTEM: ${{inputs.os}}


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need a way for our tests to determine which operating systems tests to run.

### What was the solution? (How)
Pass the operating system as an environment variable, launch windows or linux tests based on the variables value.

### What is the impact of this change?
enables workflows to run both windows and linux e2e tests

### How was this change tested?
Tested in a development account

### Was this change documented?
no

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*