### PR TITLE
ci: fix language input for codeql workflow

### DIFF
--- a/.github/workflows/reusable_codeql.yml
+++ b/.github/workflows/reusable_codeql.yml
@@ -4,10 +4,10 @@ on:
   workflow_call:
     inputs:
         languages:
-          description: "Language for CodeQL code check. Supported languages are: 'python', 'typescript', 'javascript' 'go', 'java', 'cpp', 'csharp', 'ruby'."
+          description: "Provide a comma seperated list. Supported languages are: python, typescript, javascript, go, java, cpp, csharp, ruby."
           required: false
           type: string
-          default: "['python']"
+          default: "python"
         mode:
           description: "Supports none, autobuild or manual." 
           required: false
@@ -16,19 +16,11 @@ on:
 
 jobs:
   analyze:
-    name: Analyze (${{ matrix.language }})
+    name: Analyze (${{inputs.languages}})
     runs-on: ubuntu-latest
     permissions:
       # required for all workflows
       security-events: write
-    
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-         - language: ${{fromJson(inputs.languages)}}
-           build-mode: ${{inputs.mode}}
-            
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -38,11 +30,8 @@ jobs:
       uses: github/codeql-action/init@v3
       with:
         queries: +security-and-quality
-        languages: ${{ matrix.language }}
-        build-mode: ${{ matrix.build-mode }}
+        languages: ${{inputs.languages}}
+        build-mode: ${{inputs.mode }}
     
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
-


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There is a bug passing in languages as inputs.

### What was the solution? (How)
Updated inputs the pass a string.

### What is the impact of this change?
Languages are now passed properly to the worklow 

### How was this change tested?
Tested by replicating the reusable workflow in a repository locally and confirming codeql passes. Tested that passing in multiple languages works.

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*