### PR TITLE
ci: pass in OPERATING_SYSTEM environment variable to release canary

### DIFF
--- a/.github/workflows/reusable_canary.yml
+++ b/.github/workflows/reusable_canary.yml
@@ -67,3 +67,7 @@ jobs:
           project-name: ${{inputs.repository}}-${{inputs.branch}}-${{inputs.os}}-canary
           source-version-override: refs/heads/release
           hide-cloudwatch-logs: true
+          env-vars-for-codebuild: |
+              OPERATING_SYSTEM
+        env:
+          OPERATING_SYSTEM: ${{inputs.os}}


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
OPERATING_SYSTEM environment variable was not passed to the release canary, causing the release canary to fail in worker-agent https://github.com/aws-deadline/deadline-cloud-worker-agent/actions/runs/10379133228 since it could not find the OPERATING_SYSTEM environment variable.
### What was the solution? (How)
Add the environment variable to the release canary.
### What is the impact of this change?
Worker-agent release canary should no longer fail
### How was this change tested?
Tested that the yaml works as expected, and is following conventions that of other steps.
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*