### PR TITLE
feat: adds hooks into the reusable bump and publsh workflows

### DIFF
--- a/.github/workflows/reusable_bump.yml
+++ b/.github/workflows/reusable_bump.yml
@@ -34,7 +34,7 @@ jobs:
           git config --local user.email ${{secrets.EMAIL}}
           git config --local user.name ${{secrets.USER}}
 
-      - name: Bump
+      - name: NextSemver
         run: |
           BUMP_ARGS=""
           if [[ "${{ inputs.force_version_bump }}" != "" ]]; then
@@ -50,17 +50,32 @@ jobs:
           hatch env create release
           hatch run release:deps
           NEXT_SEMVER=$(hatch run release:bump $BUMP_ARGS)
+          echo "NEXT_SEMVER=$NEXT_SEMVER" >> $GITHUB_ENV
+          git checkout -b bump/$NEXT_SEMVER
 
+      - name: GenerateChangeLog
+        run: |
           # Grab the new version's changelog and prepend it to the original changelog contents
           python .github/scripts/get_latest_changelog.py > NEW_LOG.md
           cat NEW_LOG.md CHANGELOG.bak.md > CHANGELOG.md
           rm NEW_LOG.md
 
-          git checkout -b bump/$NEXT_SEMVER
           git add CHANGELOG.md
+
+      # A precommit hook into the GitHub Action workflow.
+      # If the action .github/actions/bump_precommit_hook exists in the repository
+      # that is using this workflow, then this will run the workflow defined in that file.
+      # That workflow must be defined to accept all of the inputs in the 'with' clause below.
+      - name: PreCommitHook
+        uses: ./.github/actions/bump_precommit_hook
+        if: ${{ hashFiles('./.github/actions/bump_precommit_hook/action.yml') != '' }}
+        with:
+          semver: ${{ env.NEXT_SEMVER }}
+
+      - name: Commit
+        run: |
           git commit -sm "chore(release): $NEXT_SEMVER"
 
-          echo "NEXT_SEMVER=$NEXT_SEMVER" >> $GITHUB_ENV
           {
             echo 'RELEASE_NOTES<<EOF'
             python .github/scripts/get_latest_changelog.py

--- a/.github/workflows/reusable_publish.yml
+++ b/.github/workflows/reusable_publish.yml
@@ -81,6 +81,22 @@ jobs:
           pip install --upgrade hatch
           hatch -v build
 
+      # A precommit hook into the GitHub Action workflow.
+      # If the workflow file .github/workflows/bump_prerelease_hook.yml exists in the repository
+      # that is using this workflow, then this will run the workflow defined in that file.
+      # That workflow must be defined to accept all of the inputs in the 'with' clause below.
+      # Uses:
+      #  If a package publish needs to publish additional files to the GitHub release, then
+      #  it should use this hook to:
+      #    1. create a dist_extras/ directory
+      #    2. add all additional files to publish into that directory that aren't publishable to PyPI
+      - name: PrePushReleaseHook
+        uses: ./.github/actions/prepush_release_hook
+        if: ${{ hashFiles('./.github/actions/prepush_release_hook/action.yml') != '' }}
+        with:
+          semver: ${{ env.NEXT_SEMVER }}
+          tag: ${{ env.TAG }}
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -99,7 +115,8 @@ jobs:
 
       - name: Sign
         run: |
-          for file in dist/*; do
+          test -d dist_extras || mkdir dist_extras
+          for file in dist/* dist_extras/*; do
              printenv PGP_KEY_PASSPHRASE | gpg --batch --pinentry-mode loopback --local-user "AWS Deadline Cloud" --passphrase-fd 0 --output $file.sig --detach-sign $file
              echo "Created signature file for $file"
           done
@@ -109,7 +126,7 @@ jobs:
           GH_TOKEN: ${{ secrets.CI_TOKEN }}
         run: |
           git push origin $TAG
-          gh release create $TAG dist/* --notes "$RELEASE_NOTES"
+          gh release create $TAG dist/* dist_extras/* --notes "$RELEASE_NOTES"
 
   PublishToInternal:
     needs: Release


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

At least one repository (deadline-cloud-for-maya) has extra non-Python build artifacts that should be updated during the bump commit and then published to the GitHub releases for the repository when a new release is published. In that case, it's specifically the actual Maya plugin (i.e. the .mod file and such).

### What was the solution? (How)

Add workflow hooks into the bump and publish reusable workflows that check for the definition of a specific workflow file in the repo being built. If it exists, then it runs the workflow defined in the hook.

Trick discovered in:
 https://github.com/actions/runner/issues/2079#issuecomment-1706828903

### What is the impact of this change?

If it works, our reusable bump & publish workflows will have a hook in them that allows our other repositories to add to their functionality. e.g. To publish additional artifacts, or make additional file modifications during creation of the bump PR.

### How was this change tested?

It was not. The only way to test this might be in live. I need to check with our CI expert

### Was this change documented?

N/A

### Is this a breaking change?

It is intended to be a non-breaking change.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*