### PR TITLE
fix: expand nullglob as empty rather than glob string

### DIFF
--- a/.github/workflows/reusable_publish.yml
+++ b/.github/workflows/reusable_publish.yml
@@ -115,23 +115,21 @@ jobs:
 
       - name: Sign
         run: |
-          mkdir -p dist_extras
+          shopt -s nullglob
           for file in dist/* dist_extras/*; do
              printenv PGP_KEY_PASSPHRASE | gpg --batch --pinentry-mode loopback --local-user "AWS Deadline Cloud" --passphrase-fd 0 --output $file.sig --detach-sign $file
              echo "Created signature file for $file"
           done
+          shopt -u nullglob
 
       - name: PushRelease
         env:
           GH_TOKEN: ${{ secrets.CI_TOKEN }}
         run: |
           git push origin $TAG
-          dist_files=$(ls -A dist_extras | wc -l)
-          if [ "$dist_files" -ge 1 ]; then 
-            gh release create $TAG dist/* dist_extras/* --notes "$RELEASE_NOTES" 
-          else
-            gh release create $TAG dist/* --notes "$RELEASE_NOTES"
-          fi
+          shopt -s nullglob
+          gh release create $TAG dist/* dist_extras/* --notes "$RELEASE_NOTES" 
+          shopt -u nullglob
 
   PublishToInternal:
     needs: Release


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Our release scripting makes use of the file glob `dist_extras/*` which bash expands to the string `dist_extras/*` rather than an empty file list when the dist_extras directory is empty.

### What was the solution? (How)

Set bash's nullglob option to force the empty glob to expand to an empty set instead of the glob string.

### What is the impact of this change?

Release processes should no longer fail if they don't write files to `dist_extras/`

### How was this change tested?

Directly in a bash shell.

```
bash-3.2$ mkdir aaaa
bash-3.2$ mkdir zzzz
bash-3.2$ touch aaaa/file.txt
bash-3.2$ for f in aaaa/* zzzz/*; do echo $f; done
aaaa/file.txt
zzzz/*
bash-3.2$ echo aaaa/* zzzz/*
aaaa/file.txt zzzz/*
bash-3.2$ shopt -s nullglob
bash-3.2$ for f in aaaa/* zzzz/*; do echo $f; done
aaaa/file.txt
bash-3.2$ echo aaaa/* zzzz/*
aaaa/file.txt
bash-3.2$ shopt -u nullglob
bash-3.2$ echo aaaa/* zzzz/*
aaaa/file.txt zzzz/*
```

### Was this change documented?

N/A

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*