### PR TITLE
ci: fix syntax error in mainline canary workflow

### DIFF
--- a/.github/workflows/reusable_canary.yml
+++ b/.github/workflows/reusable_canary.yml
@@ -54,7 +54,7 @@ jobs:
           project-name: ${{inputs.repository}}-${{inputs.branch}}-${{inputs.os}}-canary
           hide-cloudwatch-logs: true
           env-vars-for-codebuild: |
-              TEST_TYPE
+              TEST_TYPE,
               OPERATING_SYSTEM
         env:
           TEST_TYPE: WHEEL


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Syntax error in the mainline canary workflow.

### What was the solution? (How)
Add missing comma

### What is the impact of this change?
Environment variables will pass to codebuild.

### How was this change tested?
n/a - works in https://github.com/aws-deadline/.github/blob/mainline/.github/workflows/reusable_e2e_test.yml

### Was this change documented?
no

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*