### PR TITLE
ci: set canary and e2e test step timeouts to 120 minutes

### DIFF
--- a/.github/workflows/reusable_canary.yml
+++ b/.github/workflows/reusable_canary.yml
@@ -48,6 +48,7 @@ jobs:
           mask-aws-account-id: true
         
       - name: Run Canary for Mainline
+        timeout-minutes: 120
         if: ${{inputs.branch == 'mainline'}}
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
@@ -61,6 +62,7 @@ jobs:
           OPERATING_SYSTEM: ${{inputs.os}}
 
       - name: Run Canary for Release
+        timeout-minutes: 120
         if: ${{inputs.branch == 'release'}}
         uses: aws-actions/aws-codebuild-run-build@v1
         with:

--- a/.github/workflows/reusable_e2e_test.yml
+++ b/.github/workflows/reusable_e2e_test.yml
@@ -47,6 +47,7 @@ jobs:
           mask-aws-account-id: true
         
       - name: Run E2E Tests
+        timeout-minutes: 120
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
           project-name: ${{inputs.repository}}-${{inputs.branch}}-${{inputs.os}}-e2e


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Some E2E tests and canaries were timing out on Github actions despite the Codebuild passing, since the Github actions step timed out after 60 minutes  (e.g. https://github.com/aws-deadline/deadline-cloud-worker-agent/actions/runs/11477666359)
### What was the solution? (How)
Change the timeout for the E2E and canary steps to 120 minutes, as some canaries can take up to 1-1.5 hours.
### What is the impact of this change?
Less flakiness in the github actions workflow due to false positives.
### How was this change tested?
Confirmed that the CI syntax checker was valid
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*