### PR TITLE
ci: increase role duration

### DIFF
--- a/.github/workflows/reusable_canary.yml
+++ b/.github/workflows/reusable_canary.yml
@@ -38,6 +38,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_CANARY_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
+          role-duration-seconds: 7200
        
       - name: Configure AWS credentials for mainline
         if: ${{inputs.branch == 'mainline'}}
@@ -46,6 +47,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_CANARY_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
+          role-duration-seconds: 7200
         
       - name: Run Canary for Mainline
         if: ${{inputs.branch == 'mainline'}}

--- a/.github/workflows/reusable_e2e_test.yml
+++ b/.github/workflows/reusable_e2e_test.yml
@@ -37,6 +37,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_E2E_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
+          role-duration-seconds: 7200
        
       - name: Configure AWS credentials for mainline
         if: ${{inputs.branch == 'mainline'}}
@@ -45,6 +46,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_E2E_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
+          role-duration-seconds: 7200
         
       - name: Run E2E Tests
         uses: aws-actions/aws-codebuild-run-build@v1


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
E2E tests are running longer than the default 1 hour role duration.

### What was the solution? (How)
Increase the Role duration to two hours for canary and mainline/release branch e2e tests.

### What is the impact of this change?
increases role duration to run tests

### How was this change tested?
Will be tested in CI

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*