### PR TITLE
chore: add step to setup ubuntu os to support pytest-qt

### DIFF
--- a/.github/workflows/reusable_python_build.yml
+++ b/.github/workflows/reusable_python_build.yml
@@ -42,7 +42,11 @@ jobs:
     - name: setup ${{ inputs.os }}
       if: inputs.os == 'ubuntu-latest'
       run: |
-        sudo apt-get install libegl1
+        sudo apt-get install -y libegl1 libdbus-1-3 libxkbcommon-x11-0 \
+          libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
+          libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 \
+          x11-utils libxcb-cursor0 libopengl0
+        
 
     - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/reusable_python_build.yml
+++ b/.github/workflows/reusable_python_build.yml
@@ -42,7 +42,7 @@ jobs:
     - name: setup ${{ inputs.os }}
       if: inputs.os == 'ubuntu-latest'
       run: |
-        apt-get update && apt-get install libgl1
+        apt-get install libgl1
 
     - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/reusable_python_build.yml
+++ b/.github/workflows/reusable_python_build.yml
@@ -42,6 +42,7 @@ jobs:
     - name: setup ${{ inputs.os }}
       if: inputs.os == 'ubuntu-latest'
       run: |
+        sudo apt-get update
         sudo apt-get install -y libegl1 libdbus-1-3 libxkbcommon-x11-0 \
           libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
           libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 \

--- a/.github/workflows/reusable_python_build.yml
+++ b/.github/workflows/reusable_python_build.yml
@@ -42,7 +42,7 @@ jobs:
     - name: setup ${{ inputs.os }}
       if: inputs.os == 'ubuntu-latest'
       run: |
-        apt-get install libgl1
+        sudo apt-get install libgl1
 
     - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/reusable_python_build.yml
+++ b/.github/workflows/reusable_python_build.yml
@@ -42,7 +42,7 @@ jobs:
     - name: setup ${{ inputs.os }}
       if: inputs.os == 'ubuntu-latest'
       run: |
-        sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils
+        apt-get update && apt-get install libgl1
 
     - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/reusable_python_build.yml
+++ b/.github/workflows/reusable_python_build.yml
@@ -42,7 +42,7 @@ jobs:
     - name: setup ${{ inputs.os }}
       if: inputs.os == 'ubuntu-latest'
       run: |
-        sudo apt-get install libgl1
+        sudo apt-get install libegl1
 
     - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/reusable_python_build.yml
+++ b/.github/workflows/reusable_python_build.yml
@@ -38,6 +38,11 @@ jobs:
       if: ${{ inputs.commit }}
       with:
         ref: ${{ inputs.commit }}
+      
+    - name: setup ${{ inputs.os }}
+      if: inputs.os == 'ubuntu-latest'
+      run: |
+        sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils
 
     - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@v5


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
pytest-qt is used to test Qt GUI for deadline cloud submitter in https://github.com/aws-deadline/deadline-cloud/pull/534.
But there are some required libs for using pytest-qt missed on ubuntu os.

### What was the solution? (How)
Create another "setup ubuntu" step in the reusable workflow to install the missed libs for pytest-qt

### What is the impact of this change?
The reusable workflow will install these libs for ubuntu os.

### How was this change tested?
The tests using pytest-qt are passed on ubuntu when using this new reusable workflow.
https://github.com/aws-deadline/deadline-cloud/pull/534

### Was this change documented?
N/A

### Is this a breaking change?
N/A
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*