### PR TITLE
feat: Added reusable workflows for stale PR/Issue management and PR l…

### DIFF
--- a/.github/workflows/reusable_label_new_prs.yml
+++ b/.github/workflows/reusable_label_new_prs.yml
@@ -1,0 +1,17 @@
+name: Label New Pull Requests
+
+on:
+    workflow_call:
+
+jobs:
+    label-new-prs:
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+        steps:
+            - name: Update pr labels
+              run:  gh pr edit "$NUMBER" --add-label "waiting-on-maintainers"
+              env:
+                GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                GH_REPO: ${{ github.repository }}
+                NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/reusable_responded.yml
+++ b/.github/workflows/reusable_responded.yml
@@ -1,0 +1,33 @@
+name: Contributor Responded
+on: 
+  workflow_call:
+    
+jobs:
+  add-reponded-to-issue:
+    # Check if an issue waiting for a contributor response has been responded to by a non-owner/non-maintainer
+    if: ${{ !github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'response-requested') && !contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association) }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add issue labels
+        run: gh issue edit "$NUMBER" --add-label "waiting-on-maintainers" --remove-label "response-requested,closing-soon"
+        env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GH_REPO: ${{ github.repository }}
+            NUMBER: ${{ github.event.issue.number }}
+  add-reponded-to-pr:
+    # Check if a PR waiting for a contributor response has been responded to by a non-owner/non-maintainer
+    if:  ${{ github.event.issue.pull_request && contains(github.event.issue.labels.*.name, 'response-requested') && !contains(fromJson('["OWNER", "MEMBER"]'), github.event.comment.author_association) }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Update pr labels
+        run: gh pr edit "$NUMBER" --add-label "waiting-on-maintainers" --remove-label "response-requested,no-pr-activity"
+        env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GH_REPO: ${{ github.repository }}
+            NUMBER: ${{ github.event.issue.number }}
+
+          

--- a/.github/workflows/reusable_stale_prs_and_issues.yml
+++ b/.github/workflows/reusable_stale_prs_and_issues.yml
@@ -1,0 +1,28 @@
+name: 'Check stale issues/PRs.'
+on: 
+  workflow_call:
+
+jobs:
+  stale-review-stage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          debug-only: false
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          days-before-stale: 5
+          days-before-close: 10
+
+          stale-issue-message: 'Greetings! It looks like this issue hasn’t been active in more than five days. We encourage you to check if this is still an issue in the latest release. In the absence of more information, we will be closing this issue soon. If you find that this is still a problem, please feel free to provide a comment or upvote with a reaction on the initial post to prevent automatic closure. If the issue is already closed, please feel free to open a new one.'
+          stale-pr-message: 'This pull request is in the review stage. It has been 5 days with no response to feedback provided by the maintainers. Please comment with an update to indicate work you are still working on the pull request. Thanks!'
+
+          stale-issue-label: closing-soon
+          stale-pr-label: no-pr-activity
+
+          labels-to-add-when-unstale: waiting-on-maintainers
+          labels-to-remove-when-unstale: response-requested,closing-soon,no-pr-activity  
+          only-labels: response-requested
+
+          close-issue-label: closed-for-staleness
+          close-pr-label: closed-for-staleness 


### PR DESCRIPTION
…abeling.

### What was the problem/requirement? (What/Why)
We want to use labels to manage issues and PRs. Labels will be used to track which items maintainers need to look at, and which items are staling out. 

### What was the solution? (How)
This PR has 3 workflows that manage the labels on PRs and Issues.

1. Labels all new PRs with the "waiting-on-maintainers" label. This lets the maintainers know that they should look at the PR. _(This is already done with the "needs triage" label for issues.)_
2. Remove the "response-requested" label and add the "waiting-on-maintainers" to issues/prs when a non-owner/maintainer comments on them.
3. A workflow to check on stale issues/prs. When an issue or pr that has the "response-requested" label hasn't been responded to in 5 days, the workflow will leave a comment and add a label saying that the item will be closing soon. After another 10 days the item will be closed.   

### What is the impact of this change?
Should help us tack issues and PRs. Keep a high level of engagement.

### How was this change tested?
I deployed these workflows to mainline of my own fork and then created workflows in another one of my forks that referenced them. 

### Was this change documented?
No. It doesn't need to be. 

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
