### PR TITLE
chore: use CodeArtifact for pip during prerelease hooks

### DIFF
--- a/.github/workflows/reusable_publish.yml
+++ b/.github/workflows/reusable_publish.yml
@@ -1,4 +1,4 @@
-name: "Publish"
+name: 'Publish'
 
 on:
   workflow_call:
@@ -46,15 +46,39 @@ jobs:
         with:
           python-version: '3.9'
 
+      # Use CodeArtifact to so that any dependencies we package up in the PrePushReleaseHook
+      # are from an internal repository.
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+
+      - name: Configure pip to use CodeArtifact
+        shell: bash
+        env:
+          CODEARTIFACT_REGION: 'us-west-2'
+          CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
+          CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
+          CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
+        run: |
+          aws codeartifact login \
+            --tool pip \
+            --domain $CODEARTIFACT_DOMAIN \
+            --domain-owner $CODEARTIFACT_ACCOUNT_ID \
+            --repository $CODEARTIFACT_REPOSITORY \
+            --region $CODEARTIFACT_REGION
+
       - name: ConfigureGit
         run: |
           git config --local user.email ${{ secrets.EMAIL }}
           git config --local user.name ${{ secrets.USER }}
-      
+
       - name: MergePushRelease
         run: |
           git merge --ff-only origin/mainline -v
-          git push origin release    
+          git push origin release
 
       - name: PrepRelease
         id: prep-release
@@ -150,7 +174,7 @@ jobs:
         with:
           project-name: ${{ github.event.repository.name }}-release-Publish
           hide-cloudwatch-logs: true
-  
+
   PublishToRepository:
     needs: PublishToInternal
     runs-on: ubuntu-latest
@@ -159,7 +183,7 @@ jobs:
       id-token: write
       contents: read
     env:
-      CODEARTIFACT_REGION: "us-west-2"
+      CODEARTIFACT_REGION: 'us-west-2'
       CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
       CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
       CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
For another PR (https://github.com/aws-deadline/deadline-cloud-for-blender/pull/197), we want to build an complete Blender add-on as part of the release process including dependencies. The build step will take place as part of prerelease hook. We want to pull these dependencies from a pip repository we own.

### What was the solution? (How)
Before running the prerelease hook, configure pip to use CodeArtifact.

I also attempted to put the CodeArtifact steps inside the specific Blender hook, but it was not able to access secrets because of a GitHub restriction with reusable workflows. Using CodeArtifact for all part of the publishing workflow seems ok and if anything, helps our security posture a bit.

### What is the impact of this change?
Pip dependencies accessed during publishing workflow will be pulled from CodeArtifact. 

### How was this change tested?
I forked this repo, set up my Blender branch to use my fork, and then set an IAM role and CodeArtifact repository to be used.  I also removed a few irrelevant steps to simplify testing. My mangled release workflow [worked](https://github.com/crowecawcaw/deadline-cloud-for-blender/actions/runs/13711312258/job/38348221652) and [produced a release](https://github.com/crowecawcaw/deadline-cloud-for-blender/releases/tag/1.2.3) with the desired artifacts. Looking at the logs, we can see that pip pulled packages from CodeArtifact. Also because the CodeArtifact domain and repo are stored as secrets, they're redacted from the logs.

### Was this change documented?
With a comment.

### Is this a breaking change?
No, CodeArtifact is compatible with the default PyPi repo.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
