### PR TITLE
fix: Update reusable installer workflow to be compatible with other projects

### DIFF
--- a/.github/workflows/reusable_build_installers.yml
+++ b/.github/workflows/reusable_build_installers.yml
@@ -3,13 +3,20 @@ name: "Build Installers"
 on:
   workflow_call:
     inputs:
-      tag:
+      ref_type:
+        required: true
+        type: string
+        default: "tags"
+      ref:
         required: true
         type: string
       oses:
         required: true
         type: string
       environment:
+        required: true
+        type: string
+      project_name:
         required: true
         type: string
         
@@ -37,6 +44,6 @@ jobs:
       - name: Build Installer
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
-          project-name: ${{github.repository}}-${{matrix.os}}Installer
-          source-version-override: refs/tag/${{inputs.tag}}
+          project-name: ${{inputs.project_name}}-${{matrix.os}}Installer
+          source-version-override: refs/${{inputs.ref_type}}/${{inputs.ref}}
           hide-cloudwatch-logs: true


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The reusable workflow for building installers had 2 issues:
1. The workflow only supported specifying a tag and not a branch
2. The workflow used the `github.repository` variable to get the calling repository name to derive the Code Build project name. This did not work because that contains the organization and the Code Build projects do not.

### What was the solution? (How)

1. Allow specifying a branch (head) or tag using new inputs
2. Add a new input so calling projects can specify their name

### What is the impact of this change?

We will be able to used the workflow

### How was this change tested?

Ran the workflow

### Was this change documented?

No

### Is this a breaking change?

Technically yes, but this workflow isn't actually being used yet

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
