### PR TITLE
chore: Added job to publish workflow to release built installers.

### DIFF
--- a/.github/workflows/reusable_publish_v2.yml
+++ b/.github/workflows/reusable_publish_v2.yml
@@ -139,15 +139,18 @@ jobs:
     name: BuildInstallers
     needs: PreRelease
     uses: aws-deadline/.github/.github/workflows/reusable_build_installers.yml@mainline
+    secrets: inherit
     if: ${{ inputs.installer_oses }}
     with:
-      tag:  ${{needs.PreRelease.outputs.tag}}
+      project_name: ${{ github.event.repository.name }} 
+      ref:  ${{needs.PreRelease.outputs.tag}}
+      ref_type: tags
       oses: ${{ inputs.installer_oses }}
       environment: release
 
   IsCondaReady:
     needs: BuildInstallers
-    if: always()
+    if: needs.BuildInstallers.result == 'success' || needs.BuildInstallers.result == 'skipped'
     runs-on: ubuntu-latest
     environment: release
     name: “Is the Conda Package available in all ProdWaves and have you ran any required manual tests?”
@@ -157,6 +160,7 @@ jobs:
 
   Release:
     needs: [IsCondaReady, PreRelease]
+    if: (needs.IsCondaReady.result == 'success' && needs.PreRelease.result == 'success')
     runs-on: ubuntu-latest
     name: Release
     permissions:
@@ -209,8 +213,40 @@ jobs:
           gh release create $TAG build-artifact/dist/* build-artifact/dist_extras/* --notes "$RELEASE_NOTES" 
           shopt -u nullglob
 
-  PublishToInternal:
+  ReleaseBuiltInstallers:
     needs: [Release, PreRelease]
+    runs-on: ubuntu-latest
+    environment: release
+    if: (needs.Release.result == 'success' && needs.PreRelease.result == 'success') && ${{ inputs.installer_oses }} 
+    permissions:
+      id-token: write
+    strategy:
+      matrix:
+        os: ${{ fromJson(inputs.installer_oses) }}    
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_INSTALLER_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+      - name: Run CodeBuild
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: ReleaseInstallerProject
+          hide-cloudwatch-logs: true
+          env-vars-for-codebuild: |
+              REPONAME,
+              OPERATING_SYSTEM,
+              VERSION
+        env:
+          REPONAME: ${{ github.event.repository.name }} 
+          OPERATING_SYSTEM: ${{ matrix.os }}
+          VERSION: ${{needs.PreRelease.outputs.tag}}
+
+  PublishToInternal:
+    needs: [ReleaseBuiltInstallers, PreRelease]
+    if: (needs.ReleaseBuiltInstallers.result == 'success' && needs.PreRelease.result == 'success')
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -234,6 +270,7 @@ jobs:
   
   PublishToRepository:
     needs: [PublishToInternal, PreRelease]
+    if: (needs.PublishToInternal.result == 'success' && needs.PreRelease.result == 'success')
     runs-on: ubuntu-latest
     environment: release
     permissions:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We want a job in the workflow that releases the built installer.

### What was the solution? (How)
Added a job that calls a codebuild project to release the built installer.

### What is the impact of this change?
Workflow one step closer to being ready for installer releases.

### How was this change tested?
I've pointed my deployment to my fork to test changes to the release workflow.

### Was this change documented?

No.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
