### PR TITLE
feat: add newly created tag to publish_v2 workflow outputs

### DIFF
--- a/.github/workflows/reusable_publish_v2.yml
+++ b/.github/workflows/reusable_publish_v2.yml
@@ -14,6 +14,10 @@ on:
       installer_oses:
         required: false
         type: string
+    outputs:
+      tag:
+        description: "The newly created tag"
+        value: ${{ jobs.PreRelease.outputs.tag }}
 
 
 jobs:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Need to consume the created tag from the calling workflow.

Example: we need to reference this tag when publishing to pypi: https://github.com/aws-deadline/deadline-cloud-for-blender/blob/mainline/.github/workflows/release_publish.yml#L34

### What was the solution? (How)

expose the newly created tag in a workflow output, taken from a job output: https://docs.github.com/en/actions/sharing-automations/reusing-workflows#using-outputs-from-a-reusable-workflow

### What is the impact of this change?

Can reference the newly created tag when calling the publish v2 workflow!

### How was this change tested?
:D

### Was this change documented?

N/A

### Is this a breaking change?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
