### PR TITLE
chore: Changed PublishToRepository from Build to Download artifact.

### DIFF
--- a/.github/workflows/reusable_publish_v2.yml
+++ b/.github/workflows/reusable_publish_v2.yml
@@ -312,8 +312,8 @@ jobs:
           pip install --upgrade hatch
           pip install --upgrade twine
 
-      - name: Build
-        run: hatch -v build
+      - name: Download
+        uses: actions/download-artifact@v4
 
       - name: Publish to Repository
         run: |


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/deadline-cloud-for-blender/actions/runs/14255822246/job/40147382407

### What was the problem/requirement? (What/Why)

The Publish to Repository job of the release workflow for Blender was failing to find artifacts. 

### What was the solution? (How)

We should be using the built artifact from the PreRelease step instead of building the artifact again. This changes makes the PublishToRepository more similar to the Release job. 

### What is the impact of this change?

Unblock releases. 

### Is this a breaking change?

No.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
