### PR TITLE
chore: Changed manual builds to no longer generate an output artifact.

### DIFF
--- a/.github/workflows/reusable_build_installers.yml
+++ b/.github/workflows/reusable_build_installers.yml
@@ -41,9 +41,20 @@ jobs:
           mask-aws-account-id: true
           role-duration-seconds: 3600
         
-      - name: Build Installer
+      - name: Build Installer Manual
+        if: github.event_name == 'workflow_dispatch'
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
           project-name: ${{inputs.project_name}}-${{matrix.os}}Installer
           source-version-override: refs/${{inputs.ref_type}}/${{inputs.ref}}
           hide-cloudwatch-logs: true
+          artifacts-type-override: NO_ARTIFACTS
+
+      - name: Build Installer Release
+        if: github.event_name != 'workflow_dispatch'
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: ${{inputs.project_name}}-${{matrix.os}}Installer
+          source-version-override: refs/${{inputs.ref_type}}/${{inputs.ref}}
+          hide-cloudwatch-logs: true
+


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We want manual builds to not produce an output artifact when run.

### What was the solution? (How)

This change uses the event name to determine if the workflow was run manually or not. (In our case, the publish workflow will continue to produce an artifact).

A separate, service side, change has been made that makes all builds upload an artifact to a know location.

Unfortunately, Github actions don't have a ternary operation. So this is the simplest way of accomplishing running builds with different parameters.

### What is the impact of this change?
No artifacts will be produced for manual builds.

### How was this change tested?
I deployed the backend to my own account and this change to my fork. I was able to verify that manually triggered builds did not produce artifacts, where as, publish workflows did. 

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
