### PR TITLE
fix: do not merge mainline into the tag for publishv2

### DIFF
--- a/.github/workflows/reusable_publish_v2.yml
+++ b/.github/workflows/reusable_publish_v2.yml
@@ -83,10 +83,6 @@ jobs:
           git config --local user.email ${{ secrets.EMAIL }}
           git config --local user.name ${{ secrets.USER }}
       
-      - name: MergePushRelease
-        run: |
-          git merge --ff-only origin/mainline -v
-
       - name: PrepRelease
         id: prep-release
         run: |


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The workflow was merging mainline in to the tag. Shouldn't do that

### What was the solution? (How)

Don't do it

### What is the impact of this change?
N/A

### How was this change tested?
N/A

### Was this change documented?
N/A

### Is this a breaking change?
N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
