### PR TITLE
chore: Separate Publish workflow into retryable workflows.

### DIFF
--- a/.github/workflows/reusable_build_installers.yml
+++ b/.github/workflows/reusable_build_installers.yml
@@ -42,7 +42,7 @@ jobs:
           role-duration-seconds: 3600
         
       - name: Build Installer Manual
-        if: github.event_name == 'workflow_dispatch'
+        if: github.workflow == 'Build Installers'
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
           project-name: ${{inputs.project_name}}-${{matrix.os}}Installer
@@ -51,7 +51,7 @@ jobs:
           artifacts-type-override: NO_ARTIFACTS
 
       - name: Build Installer Release
-        if: github.event_name != 'workflow_dispatch'
+        if: github.workflow != 'Build Installers'
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
           project-name: ${{inputs.project_name}}-${{matrix.os}}Installer

--- a/.github/workflows/reusable_create_new_tag.yml
+++ b/.github/workflows/reusable_create_new_tag.yml
@@ -1,0 +1,41 @@
+name: "Create new Tag"
+
+on:
+  workflow_call:
+  
+
+jobs:
+  CreateTag:
+    runs-on: ubuntu-latest
+    outputs: 
+      tag: ${{steps.prep-release.outputs.TAG}}
+      semvar: ${{steps.prep-release.outputs.NEXT_SEMVER}}
+      release_notes: ${{steps.prep-release.outputs.RELEASE_NOTES}}
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{github.ref}}
+          fetch-depth: 0
+      - name: ConfigureGit
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "github-actions@github.com"
+      - name: PrepMainlineRelease
+        id: prep-release
+        run: |
+            COMMIT_TITLE=$(git show -s --format='%s' HEAD)
+            NEXT_SEMVER=$(python -c 'import sys, re; print(re.match(r"chore\(release\): ([0-9]+\.[0-9]+\.[0-9]+).*", sys.argv[1]).group(1))' "$COMMIT_TITLE")
+  
+            # The format of the tag must match the pattern in pyproject.toml -> tool.semantic_release.tag_format
+            TAG="$NEXT_SEMVER"
+  
+            git tag -a $TAG -m "Release $TAG"
+  
+            echo "TAG=$TAG" >> $GITHUB_OUTPUT
+            echo "NEXT_SEMVER=$NEXT_SEMVER" >> $GITHUB_OUTPUT
+              
+            git push origin $TAG

--- a/.github/workflows/reusable_prerelease.yml
+++ b/.github/workflows/reusable_prerelease.yml
@@ -1,0 +1,148 @@
+name: "Prerelease"
+
+on:
+  workflow_call:
+    inputs:
+      oses:
+        required: false
+        type: string
+        default: "['ubuntu-latest', 'windows-latest', 'macos-latest']"
+      python-versions:
+        required: false
+        type: string
+        default: "['3.9', '3.10', '3.11', '3.12']"
+      installer_oses:
+        required: false
+        type: string
+      tag:
+        required: true
+        type: string
+    outputs:
+      tag:
+        description: "The published tag"
+        value: ${{ inputs.tag }}
+
+
+jobs:
+  VerifyCommit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{inputs.tag}}
+          fetch-depth: 0
+
+      - name: VerifyAuthor
+        run: |
+          EXPECTED_AUTHOR=${{secrets.EMAIL}}
+          AUTHOR=$(git show -s --format='%ae' HEAD)
+          if [[ $AUTHOR != $EXPECTED_AUTHOR ]]; then
+            echo "ERROR: Expected author email to be '$EXPECTED_AUTHOR', but got '$AUTHOR'. Aborting release."
+            exit 1
+          else
+            echo "Verified author email ($AUTHOR) is as expected ($EXPECTED_AUTHOR)"
+          fi
+
+  UnitTests:
+    needs: VerifyCommit
+    name: UnitTests
+    strategy:
+      matrix:
+        os: ${{ fromJson(inputs.oses) }}
+        python-version: ${{ fromJson(inputs.python-versions) }}
+    uses: ./.github/workflows/reusable_python_build.yml
+    with:
+      os: ${{ matrix.os }}
+      python-version: ${{ matrix.python-version }}
+      ref: ${{inputs.tag}}
+      
+  PreRelease:
+    needs: UnitTests
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: refs/tags/${{inputs.tag}}
+          fetch-depth: 0
+          token: ${{ secrets.CI_TOKEN }}
+
+      - name: Build
+        run: |
+          pip install --upgrade hatch
+          hatch -v build
+
+      # A precommit hook into the GitHub Action workflow.
+      # If the workflow file .github/actions/prepush_release_hook exists in the repository
+      # that is using this workflow, then this will run the workflow defined in that file.
+      # That workflow must be defined to accept all of the inputs in the 'with' clause below.
+      # Uses:
+      #  If a package publish needs to publish additional files to the GitHub release, then
+      #  it should use this hook to:
+      #    1. create a dist_extras/ directory
+      #    2. add all additional files to publish into that directory that aren't publishable to PyPI
+      - name: PrePushReleaseHook
+        uses: ./.github/actions/prepush_release_hook
+        if: ${{ hashFiles('./.github/actions/prepush_release_hook/action.yml') != '' }}
+        with:
+          semver: ${{ inputs.tag }}
+          tag: ${{ inputs.tag }}
+
+      - name: UploadArtifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact
+          path: |
+            dist
+            dist_extras
+    
+  BuildInstallers:
+    name: BuildInstallers
+    needs: PreRelease
+    uses: erico-aws/.github/.github/workflows/reusable_build_installers.yml@mainline
+    secrets: inherit
+    if: ${{ inputs.installer_oses }}
+    with:
+      project_name: ${{ github.event.repository.name }} 
+      ref:  ${{inputs.tag}}
+      ref_type: tags
+      oses: ${{ inputs.installer_oses }}
+      environment: release
+
+  StageBuiltInstallers:
+    needs: BuildInstallers
+    runs-on: ubuntu-latest
+    environment: release
+    if: needs.Release.result == 'success' && ${{ inputs.installer_oses }} 
+    permissions:
+        id-token: write
+    strategy:
+        matrix:
+          os: ${{ fromJson(inputs.installer_oses) }}    
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+            role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_INSTALLER_ROLE }}
+            aws-region: us-west-2
+            mask-aws-account-id: true
+      - name: Run CodeBuild
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+            project-name: ReleaseInstallerProject
+            hide-cloudwatch-logs: true
+            env-vars-for-codebuild: |
+                REPONAME,
+                OPERATING_SYSTEM,
+                VERSION
+        env:
+            REPONAME: ${{ github.event.repository.name }} 
+            OPERATING_SYSTEM: ${{ matrix.os }}
+            VERSION: ${{inputs.tag}}

--- a/.github/workflows/reusable_publish_python.yml
+++ b/.github/workflows/reusable_publish_python.yml
@@ -1,0 +1,84 @@
+name: "Publish Python Package"
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+        
+jobs:
+  PublishToInternal:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_PUBLISH_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+
+      - name: Run CodeBuild
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: ${{ github.event.repository.name }}-release-Publish
+          hide-cloudwatch-logs: true
+          source-version-override: refs/tags/${{inputs.tag}}
+  
+  PublishToRepository:
+    needs: PublishToInternal
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      CODEARTIFACT_REGION: "us-west-2"
+      CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
+      CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
+      CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
+      CUSTOMER_DOMAIN: ${{ secrets.CUSTOMER_DOMAIN }}
+      CUSTOMER_REPOSITORY: ${{ secrets.CUSTOMER_REPOSITORY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{inputs.tag}}
+          fetch-depth: 0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade hatch
+          pip install --upgrade twine
+
+      - name: Download
+        uses: actions/download-artifact@v4
+
+      - name: Publish to Repository
+        run: |
+          export TWINE_USERNAME=aws
+          export TWINE_PASSWORD=`aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text`
+          export TWINE_REPOSITORY_URL=`aws codeartifact get-repository-endpoint --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --repository ${{ secrets.CODEARTIFACT_REPOSITORY }} --format pypi --query repositoryEndpoint --output text`
+          twine upload build-artifact/dist/*
+
+      - name: Publish to Customer Repository
+        run: |
+          export TWINE_USERNAME=aws
+          export TWINE_PASSWORD=`aws codeartifact get-authorization-token --domain ${{ secrets.CUSTOMER_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text`
+          export TWINE_REPOSITORY_URL=`aws codeartifact get-repository-endpoint --domain ${{ secrets.CUSTOMER_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --repository ${{ secrets.CUSTOMER_REPOSITORY }} --format pypi --query repositoryEndpoint --output text`
+          twine upload build-artifact/dist/*

--- a/.github/workflows/reusable_python_build.yml
+++ b/.github/workflows/reusable_python_build.yml
@@ -9,6 +9,9 @@ on:
       commit:
         required: false
         type: string
+      ref:
+        required: false
+        type: string
       python-version:
         required: true
         type: string
@@ -26,7 +29,7 @@ jobs:
       PYTHON: ${{ inputs.python-version }}
     steps:
     - uses: actions/checkout@v4
-      if: ${{ !inputs.branch && !inputs.commit }}
+      if: ${{ !inputs.branch && !inputs.commit && !inputs.ref }}
 
     - uses: actions/checkout@v4
       if: ${{ inputs.branch }}
@@ -38,6 +41,11 @@ jobs:
       if: ${{ inputs.commit }}
       with:
         ref: ${{ inputs.commit }}
+
+    - uses: actions/checkout@v4
+      if: ${{ inputs.ref }}
+      with:
+        ref: ${{ inputs.ref }}
       
     - name: setup ${{ inputs.os }}
       if: inputs.os == 'ubuntu-latest'

--- a/.github/workflows/reusable_release.yml
+++ b/.github/workflows/reusable_release.yml
@@ -1,0 +1,70 @@
+name: "Github Release"
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+
+
+jobs:
+  Release:
+    runs-on: ubuntu-latest
+    name: Release
+    permissions:
+      id-token: write
+      contents: write
+    environment: release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{inputs.tag}}
+          fetch-depth: 0
+          token: ${{ secrets.CI_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
+      - name: Download
+        uses: actions/download-artifact@v4
+        
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PGP_KEY_SECRET_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+
+      - name: Import PGP Key
+        run: |
+          export SECRET_STRING="$(aws secretsmanager get-secret-value --secret-id ${{ secrets.AWS_PGP_KEY_SECRET }} --query 'SecretString')"
+          printenv SECRET_STRING | jq -r '. | fromjson | .PrivateKey' | gpg --batch --pinentry-mode loopback --import --armor
+
+          PGP_KEY_PASSPHRASE=$(printenv SECRET_STRING | jq -r '. | fromjson | .Passphrase')
+          echo "::add-mask::$PGP_KEY_PASSPHRASE"
+          echo "PGP_KEY_PASSPHRASE=$PGP_KEY_PASSPHRASE" >> $GITHUB_ENV
+
+      - name: Sign
+        run: |
+          shopt -s nullglob
+          for file in build-artifact/dist/* build-artifact/dist_extras/*; do
+             printenv PGP_KEY_PASSPHRASE | gpg --batch --pinentry-mode loopback --local-user "AWS Deadline Cloud" --passphrase-fd 0 --output $file.sig --detach-sign $file
+             echo "Created signature file for $file"
+          done
+          shopt -u nullglob
+
+      - name: PushRelease
+        env:
+          GH_TOKEN: ${{ secrets.CI_TOKEN }}
+        run: |
+          RELEASE_NOTE=$(python .github/scripts/get_latest_changelog.py)
+      
+          shopt -s nullglob
+          gh release create $TAG build-artifact/dist/* build-artifact/dist_extras/* --notes "$RELEASE_NOTES" 
+
+
+ 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Some parts of the current publish workflow don't apply to all dccs, like the python publishing. 


### What was the solution? (How)

I've separated the publish workflow into 3 main parts. 
1. A prerelease workflow.
2. A release workflow
3. A python publish workflow

The idea with this set of workflows is that the calling workflow will provide these with a tag to build, test, release off of. This will allow the calling workflow to be run multiple times. (Before, the publish workflow would fail when trying to create a tag that already exists. We also had the publish workflow run on a change to the changelog. With this change, we can re-run the workflow targeting the tag without having to redo the changelog)

I've also changed build installers. Our logic around whether to publish artifacts doesn't work anymore now that the calling workflow can be triggered manually. I've changed it to use the name of that workflow instead.

I've also added a ref option to python_build.

### What is the impact of this change?

Enables us to write re-runnable workflows and enables all dccs to use these workflows.

### How was this change tested?

Deployed these changes to my fork and made corresponding changes to my Blender fork. Ran the bump action and the release action from my fork and verified the action succeeded. 

### Was this change documented?

No

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
