### PR TITLE
fix: reusable_publish_v2 is not setting the release notes

### DIFF
--- a/.github/workflows/reusable_publish_v2.yml
+++ b/.github/workflows/reusable_publish_v2.yml
@@ -97,12 +97,7 @@ jobs:
           echo "TAG=$TAG" >> $GITHUB_ENV
           echo "TAG=$TAG" >> $GITHUB_OUTPUT
           echo "NEXT_SEMVER=$NEXT_SEMVER" >> $GITHUB_ENV
-          {
-            echo 'RELEASE_NOTES<<EOF'
-            python .github/scripts/get_latest_changelog.py
-            echo EOF
-          } >> $GITHUB_ENV
-            # Tag must be made before building so the generated _version.py files have the correct version
+          # Tag must be made before building so the generated _version.py files have the correct version
             
           git push origin $TAG
 
@@ -204,6 +199,14 @@ jobs:
              echo "Created signature file for $file"
           done
           shopt -u nullglob
+
+      - name: Generate Release Notes
+        run: |
+          {
+            echo 'RELEASE_NOTES<<EOF'
+            python .github/scripts/get_latest_changelog.py
+            echo EOF
+          } >> $GITHUB_ENV
 
       - name: PushRelease
         env:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The `PreRelease` Job is setting the `RELEASE_NOTES` env, but `GITHUB_ENV` does not persist between jobs. You would need to pass this to the `Release` job as an output

### What was the solution? (How)
`RELEASE_NOTES` is not being used in `PreRelease`. Moved the code to the `Release` job so the notes should now be set in the GitHub Release,

### What is the impact of this change?
Release Notes are populated with change logs

### How was this change tested?
I did some minimal testing.

1. I stripped down the reusable_publish_v2 to only the PreRelease and Release Jobs: https://github.com/moorec-aws/.github/commit/e1c4e0e3b14208bb913894b617e34db327f3fac5
2. I updated my nuke fork to point to that version of reusable_publish and ran it: https://github.com/moorec-aws/deadline-cloud-for-nuke/actions/runs/15195683930 
3. confirmed release notes are written: https://github.com/moorec-aws/deadline-cloud-for-nuke/releases/tag/0.1.0

### Was this change documented?
n/a

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
