### PR TITLE
chore: create tag on commit instead of branch

### DIFF
--- a/.github/workflows/reusable_e2e_test.yml
+++ b/.github/workflows/reusable_e2e_test.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       branch:
-        required: true
+        required: false
         type: string
       environment:
         required: true
@@ -21,6 +21,7 @@ on:
 
 jobs:
   E2ETests:
+    if: (github.repository == 'aws-deadline/${{inputs.repository}}')
     name: E2E Tests
     runs-on: ubuntu-latest
     environment: ${{inputs.environment}}
@@ -29,7 +30,7 @@ jobs:
       contents: read
     steps:
       - name: Configure AWS credentials for release
-        if: ${{inputs.branch == 'release'}}
+        if: ${{inputs.environment == 'release'}}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_E2E_ROLE }}
@@ -38,7 +39,7 @@ jobs:
           role-duration-seconds: 7200
        
       - name: Configure AWS credentials for mainline
-        if: ${{inputs.branch == 'mainline'}}
+        if: ${{inputs.environment == 'mainline'}}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_E2E_ROLE }}
@@ -49,7 +50,7 @@ jobs:
       - name: Run E2E Tests
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
-          project-name: ${{inputs.repository}}-${{inputs.branch}}-${{inputs.os}}-e2e
+          project-name: ${{inputs.repository}}-${{inputs.environment}}-${{inputs.os}}-e2e
           hide-cloudwatch-logs: true
           source-version-override: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || inputs.branch }}
           env-vars-for-codebuild: |

--- a/.github/workflows/reusable_integration_test.yml
+++ b/.github/workflows/reusable_integration_test.yml
@@ -7,13 +7,16 @@ on:
         required: true
         type: string
       branch:
-        required: true
+        required: false
         type: string
       environment:
         required: true
         type: string
       os:
         required: true
+        type: string
+      tag:
+        required: false
         type: string
 
 jobs:
@@ -26,13 +29,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
-        if: ${{inputs.branch == 'mainline' || inputs.branch == 'release'}}
-        with:
-          ref: ${{inputs.branch}}
-      
       - name: Configure AWS credentials for release
-        if: ${{inputs.branch == 'release'}}
+        if: ${{inputs.environment == 'release'}}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_INTEG_ROLE }}
@@ -40,7 +38,7 @@ jobs:
           mask-aws-account-id: true
        
       - name: Configure AWS credentials for mainline
-        if: ${{inputs.branch == 'mainline'}}
+        if: ${{inputs.environment == 'mainline'}}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_INTEG_ROLE }}
@@ -50,8 +48,9 @@ jobs:
       - name: Run Integration Tests
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
-          project-name: ${{inputs.repository}}-${{inputs.branch}}-${{inputs.os}}-integ
+          project-name: ${{inputs.repository}}-${{inputs.environment}}-${{inputs.os}}-integ
           hide-cloudwatch-logs: true
+          source-version-override: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || inputs.branch }}
           env-vars-for-codebuild: |
               TEST_TYPE,
               OPERATING_SYSTEM

--- a/.github/workflows/reusable_tag_release.yml
+++ b/.github/workflows/reusable_tag_release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{github.ref}}
+          ref: ${{ inputs.tag || github.sha }}
           fetch-depth: 0
           token: ${{ secrets.CI_TOKEN }}
           


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The checkout in the tag workflow is currently referencing `github.ref` which will checkout the mainline branch. We instead want it to checkout the commit of the push that starts the workflow (the release change log PR). 

The e2e/integ tests are differentiating flows via branch name. Since we are moving away from branch focused releases we need to differentiate via environment.

### What was the solution? (How)
1. Update the reusable_tag_release.yml checkout job to checkout the tag if provided, otherwise you the commit sha of the push that triggered the workflow.
2. Update e2e/integ workflows to differentiate flows via environment instead of branch.

### What is the impact of this change?
Allows onboarding of the deadline-cloud repository to this workflow. Creating tags on the commit versus the branch prevents unexpected code from sneaking into a release

### How was this change tested?
Tested in a development environment using deadline-cloud repository.

https://github.com/moorec-aws/deadline-cloud/actions/runs/15494791266
https://github.com/moorec-aws/deadline-cloud/actions/runs/15494766056

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
