### PR TITLE
ci: create an installer release workflow

### DIFF
--- a/.github/workflows/reusable_release_installers.yml
+++ b/.github/workflows/reusable_release_installers.yml
@@ -1,0 +1,42 @@
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      oses:
+        required: true
+        type: string
+      project_name:
+        required: true
+        type: string
+
+jobs:
+  ReleaseInstaller:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    strategy:
+      matrix:
+        os: ${{ fromJson(inputs.oses) }}    
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_INSTALLER_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+      - name: Run CodeBuild
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: ReleaseInstallerProject
+          hide-cloudwatch-logs: true
+          env-vars-for-codebuild: |
+              REPONAME,
+              OPERATING_SYSTEM,
+              VERSION
+        env:
+          REPONAME: ${{ inputs.project_name }}
+          OPERATING_SYSTEM: ${{ matrix.os }}
+          VERSION: ${{ inputs.tag }}


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There are cases where we want to build and release installers at different points in time.

### What was the solution? (How)
Add a workflow that only performs the installer release.

### What is the impact of this change?
adds additional release options

### How was this change tested?
Tested in a fork of the blender repo:

https://github.com/moorec-aws/deadline-cloud-for-blender/actions/runs/16326741245

### Was this change documented?
No

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
