### PR TITLE
docs: Update README.md for VRED support

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -43,6 +43,7 @@ This GitHub org has integrations (such as job submission plugins) for a selectio
  | [Autodesk 3ds Max](https://www.autodesk.com/products/3ds-max/overview) | [deadline-cloud-for-3ds-max](https://github.com/aws-deadline/deadline-cloud-for-3ds-max)
  | [Autodesk Arnold for Maya](https://www.autodesk.com/products/arnold/overview) | [deadline-cloud-for-maya](https://github.com/aws-deadline/deadline-cloud-for-maya)
  | [Autodesk Maya](https://www.autodesk.com/products/maya/overview/) | [deadline-cloud-for-maya](https://github.com/aws-deadline/deadline-cloud-for-maya)
+ | [Autodesk VRED](https://www.autodesk.com/products/vred/overview/) | [deadline-cloud-for-vred](https://github.com/aws-deadline/deadline-cloud-for-vred)
  | [Blender](https://blender.org) | [deadline-cloud-for-blender](https://github.com/aws-deadline/deadline-cloud-for-blender)
  | [Chaos V-Ray for Maya](https://www.chaos.com/vray/maya) | [deadline-cloud-for-maya](https://github.com/aws-deadline/deadline-cloud-for-maya)
  | [Foundry Nuke](https://www.foundry.com/products/nuke-family/nuke) | [deadline-cloud-for-nuke](https://github.com/aws-deadline/deadline-cloud-for-nuke)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Deadline Cloud now supports VRED 2025, 2026 workloads on SMF

### What was the solution? (How)
Update readme to add VRED support

### What is the impact of this change?
We want customers to use VRED!

### How was this change tested?
Docs only.

### Was this change documented?
Docs only.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
