### PR TITLE
chore: allow running bump off non-mainline branches

### DIFF
--- a/.github/workflows/reusable_bump.yml
+++ b/.github/workflows/reusable_bump.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: mainline
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
           token: ${{ secrets.CI_TOKEN }}
 
@@ -89,4 +89,4 @@ jobs:
           git push -u origin bump/$NEXT_SEMVER
 
           # Needs "Allow GitHub Actions to create and approve pull requests" under Settings > Actions
-          gh pr create --base mainline --title "chore(release): $NEXT_SEMVER" --body "$RELEASE_NOTES"
+          gh pr create --base ${{ github.ref_name }} --title "chore(release): $NEXT_SEMVER" --body "$RELEASE_NOTES"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We are looking to do a patch release and need to be able to start releases off of branches that are not mainline

### What was the solution? (How)

Pass in the branch reference to the release bump workflow

### What is the impact of this change?

We can start releases off of branches that are not mainline

### How was this change tested?

Tested in forked dev env:
- https://github.com/moorec-aws/deadline-cloud/actions/runs/16790161131
- https://github.com/moorec-aws/deadline-cloud/pull/5
- https://github.com/moorec-aws/deadline-cloud/releases/tag/0.51.1
- https://github.com/moorec-aws/deadline-cloud/actions/runs/16790466209
- https://github.com/moorec-aws/deadline-cloud/releases/tag/0.51.1

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
