### PR TITLE
chore: Changes reusable bump to use release:version for semver

### DIFF
--- a/.github/workflows/reusable_bump.yml
+++ b/.github/workflows/reusable_bump.yml
@@ -49,7 +49,7 @@ jobs:
           pip install --upgrade hatch
           hatch env create release
           hatch run release:deps
-          NEXT_SEMVER=$(hatch run release:bump $BUMP_ARGS)
+          NEXT_SEMVER=$(hatch run release:version $BUMP_ARGS)
           echo "NEXT_SEMVER=$NEXT_SEMVER" >> $GITHUB_ENV
           git checkout -b bump/$NEXT_SEMVER
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We tried updating our dependency of python-semantic-version to 10.3 which caused the release bump workflow to fail: https://github.com/aws-deadline/deadline-cloud-for-vred/actions/runs/16761831227/job/47458697404

### What was the solution? (How)
We just need to change the shared release bump workflow to use the `version` command instead of `bump`, which prints the version in the `commit_sha` format the semver tool expects.

### What is the impact of this change?
We should be free to update our dependency on python-semantic-version to 10.3

### How was this change tested?
Did a test release bump workflow on my own fork of the VRED package, using changes from this PR. Confirmed it worked fine with the default version 10.2, then upgraded to 10.3 and confirmed that worked too.

(10.2) https://github.com/marofke/deadline-cloud-for-vred/actions/runs/16815819116/job/47632872451

(10.3) https://github.com/marofke/deadline-cloud-for-vred/actions/runs/16816225086/job/47633563984

Manually verified that the `version` command exists in all of our repos:
- https://github.com/aws-deadline/deadline-cloud-for-after-effects/blob/mainline/hatch.toml#L13
- https://github.com/aws-deadline/deadline-cloud-for-3ds-max/blob/mainline/hatch.toml#L53
- https://github.com/aws-deadline/deadline-cloud-for-maya/blob/mainline/hatch.toml#L60
- https://github.com/aws-deadline/deadline-cloud-for-vred/blob/mainline/hatch.toml#L71
- https://github.com/aws-deadline/deadline-cloud-for-blender/blob/mainline/hatch.toml#L59
- https://github.com/aws-deadline/deadline-cloud-for-nuke/blob/mainline/hatch.toml#L55
- https://github.com/aws-deadline/deadline-cloud-for-keyshot/blob/mainline/hatch.toml#L51
- https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/hatch.toml#L42
- https://github.com/aws-deadline/deadline-cloud-for-houdini/blob/mainline/hatch.toml#L61
- https://github.com/aws-deadline/deadline-cloud-for-unreal-engine/blob/mainline/hatch.toml#L42
- https://github.com/aws-deadline/deadline-cloud/blob/mainline/hatch.toml#L55
- https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/mainline/hatch.toml#L50

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
