### PR TITLE
chore: bump reusable_bump to support semantic release 10.3

### DIFF
--- a/.github/workflows/reusable_bump.yml
+++ b/.github/workflows/reusable_bump.yml
@@ -45,10 +45,15 @@ jobs:
           touch CHANGELOG.md
           cp CHANGELOG.md CHANGELOG.bak.md
 
+          # Install semantic-release from requirements file
+          pip install -r requirements-release.txt
+          
           # Run semantic-release to generate new changelog
-          pip install --upgrade hatch
-          hatch env create release
-          hatch run release:deps
+          NEXT_SEMVER=$(semantic-release -v --strict version --no-push --no-tag --skip-build $BUMP_ARGS)
+
+          # Reset the semantic-release commit but keep the file changes
+          git reset --soft HEAD~1
+
           NEXT_SEMVER=$(hatch run release:version $BUMP_ARGS)
           echo "NEXT_SEMVER=$NEXT_SEMVER" >> $GITHUB_ENV
           git checkout -b bump/$NEXT_SEMVER


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
in semantic versioning 10.3 `--no-comit` no longer works in github actions since github actions now requires a commit-sha output from python-semantic-versioning.

```
Skipping build due to --skip-build flag
Error:  some required outputs were not set: commit_sha
Run semantic-release in very verbose mode (-vv) to see the full traceback.
Error: Process completed with exit code 1.
```

### What was the solution? (How)
As a workaround we are removing `--no-commit` and then doing a soft reset to keep the changelog changes but remove the commit, since we make our own later in the workflow.

I have also transitioned the `semantic-release` commands to the workflow itself instead of relying on each repositories hatch configuration so that we can control these from a single location rather than having to replicate changes across all repositories.

### What is the impact of this change?

Makes bump workflow compatible with python-semantic-version 10.3.

### How was this change tested?

Workflow: https://github.com/moorec-aws/deadline-cloud/actions/runs/16832862758/job/47684774635
ChangeLog: https://github.com/moorec-aws/deadline-cloud/pull/6

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
