### PR TITLE
ci: remove hatch release:version from bump workflow

### DIFF
--- a/.github/workflows/reusable_bump.yml
+++ b/.github/workflows/reusable_bump.yml
@@ -54,7 +54,6 @@ jobs:
           # Reset the semantic-release commit but keep the file changes
           git reset --soft HEAD~1
 
-          NEXT_SEMVER=$(hatch run release:version $BUMP_ARGS)
           echo "NEXT_SEMVER=$NEXT_SEMVER" >> $GITHUB_ENV
           git checkout -b bump/$NEXT_SEMVER
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
hatch is not used to run semantic versioning calls anymore.

### What was the solution? (How)
remove un-needed hatch call

### What is the impact of this change?
bump workflow uses semantic versioning calls directly

### How was this change tested?

https://github.com/moorec-aws/deadline-cloud/actions/runs/16832862758/job/47684774635

### Was this change documented?

*delete text starting here*
- Did you update all relevant docstrings for functions that you modified?
- Should the README.md, DEVELOPMENT.md, or other documents in the repository's docs/ directory be updated along with your change?
*delete text ending here*

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
