### PR TITLE
chore: enable pytest colors by default in GH Actions

### DIFF
--- a/.github/workflows/reusable_python_build.yml
+++ b/.github/workflows/reusable_python_build.yml
@@ -27,6 +27,7 @@ jobs:
       contents: read
     env:
       PYTHON: ${{ inputs.python-version }}
+      PY_COLORS: 1
     steps:
     - uses: actions/checkout@v4
       if: ${{ !inputs.branch && !inputs.commit && !inputs.ref }}


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Follow up to changes like: https://github.com/aws-deadline/deadline-cloud/pull/813

1. CodeBuild shouldn't enable color
2. GitHub Actions should enable color

### What was the solution? (How)

Set env variable to enable colors in pytest: https://docs.pytest.org/en/7.1.x/reference/reference.html#envvar-PY_COLORS

### What is the impact of this change?

Colors!

### How was this change tested?

😬 

### Was this change documented?

N/A

### Is this a breaking change?

No - this is specifically for the reusable builds that run directly in github and all the repos already force color minus the worker agent/deadline-cloud client

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
