### PR TITLE
fix: pin click version that hatch uses due to sentinel bug

### DIFF
--- a/.github/workflows/reusable_prerelease.yml
+++ b/.github/workflows/reusable_prerelease.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build
         run: |
-          pip install --upgrade hatch
+          pip install --upgrade hatch click==8.2
           hatch -v build
 
       # A precommit hook into the GitHub Action workflow.

--- a/.github/workflows/reusable_publish.yml
+++ b/.github/workflows/reusable_publish.yml
@@ -102,7 +102,7 @@ jobs:
       # Tag must be made before building so the generated _version.py files have the correct version
       - name: Build
         run: |
-          pip install --upgrade hatch
+          pip install --upgrade hatch click==8.2
           hatch -v build
 
       # A precommit hook into the GitHub Action workflow.
@@ -210,7 +210,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch
+          pip install --upgrade hatch click==8.2
           pip install --upgrade twine
 
       - name: Build

--- a/.github/workflows/reusable_publish_v2.yml
+++ b/.github/workflows/reusable_publish_v2.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Build
         run: |
-          pip install --upgrade hatch
+          pip install --upgrade hatch click==8.2
           hatch -v build
 
       # A precommit hook into the GitHub Action workflow.
@@ -308,7 +308,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch
+          pip install --upgrade hatch click==8.2
           pip install --upgrade twine
 
       - name: Download

--- a/.github/workflows/reusable_python_build.yml
+++ b/.github/workflows/reusable_python_build.yml
@@ -65,7 +65,7 @@ jobs:
 
     - name: Install Hatch
       run: |
-        pip install --upgrade hatch
+        pip install --upgrade hatch click==8.2
 
     - name: Run Linting
       run: hatch -v run lint


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

code quality checks are failing when running hatch with click==8.3.0.

Root cause:
* https://github.com/pypa/hatch/issues/2050
* https://github.com/pallets/click/issues/3065

### What was the solution? (How)

pin to 8.2.0 until either hatch pins upperbound or click releases a new version that hatch works with.

### What is the impact of this change?

working infrastructure

### How was this change tested?

Ran the command locally and it installed the desired click version. 

### Was this change documented?

N/A

### Is this a breaking change?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
