### PR TITLE
chore: Revert commits 1140193991b1caf34902568fe97a86b2a03beee4 and 99…

### DIFF
--- a/.github/workflows/reusable_prerelease.yml
+++ b/.github/workflows/reusable_prerelease.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build
         run: |
-          pip install --upgrade hatch "click<8.3"
+          pip install --upgrade hatch
           hatch -v build
 
       # A precommit hook into the GitHub Action workflow.

--- a/.github/workflows/reusable_publish.yml
+++ b/.github/workflows/reusable_publish.yml
@@ -102,7 +102,7 @@ jobs:
       # Tag must be made before building so the generated _version.py files have the correct version
       - name: Build
         run: |
-          pip install --upgrade hatch "click<8.3"
+          pip install --upgrade hatch
           hatch -v build
 
       # A precommit hook into the GitHub Action workflow.
@@ -210,7 +210,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch "click<8.3"
+          pip install --upgrade hatch
           pip install --upgrade twine
 
       - name: Build

--- a/.github/workflows/reusable_publish_v2.yml
+++ b/.github/workflows/reusable_publish_v2.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Build
         run: |
-          pip install --upgrade hatch "click<8.3"
+          pip install --upgrade hatch
           hatch -v build
 
       # A precommit hook into the GitHub Action workflow.
@@ -308,7 +308,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch "click<8.3"
+          pip install --upgrade hatch
           pip install --upgrade twine
 
       - name: Download

--- a/.github/workflows/reusable_python_build.yml
+++ b/.github/workflows/reusable_python_build.yml
@@ -65,7 +65,7 @@ jobs:
 
     - name: Install Hatch
       run: |
-        pip install --upgrade hatch "click<8.3"
+        pip install --upgrade hatch
 
     - name: Run Linting
       run: hatch -v run lint


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Hatch has fixed an issue with it's click dependency. We no longer need to pin click.

Hatch Release: https://github.com/pypa/hatch/releases/tag/hatch-v1.14.2

### What was the solution? (How)
Reverted: 

https://github.com/aws-deadline/.github/commit/1140193991b1caf34902568fe97a86b2a03beee4
and 
https://github.com/aws-deadline/.github/commit/99ea7943aa5194f57252ca3a604532f336d3028b

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
