### PR TITLE
fix: add back mobile sidenav header

### DIFF
--- a/overrides/stylesheets/extra.css
+++ b/overrides/stylesheets/extra.css
@@ -62,7 +62,8 @@ img {
   border-radius: 10px;
 }
 
-/* Hide sidenav title, it's unnecessary */
 .md-nav__title {
-  display: none;
+  /* Fix some styling with the sidenav title when not on mobile */
+  background: none !important;
+  box-shadow: none !important;
 }


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The sidenav header has some CSS to hide it. It's not necessary on the desktop view, but in the mobile view, it's an important component for navigating the menus.

### What was the solution? (How)
Add it back and override some of the styling for the desktop view.

Desktop view:
<img width="322" height="203" alt="Screenshot 2025-10-08 at 1 34 17 PM" src="https://github.com/user-attachments/assets/d193932f-b9a5-4eff-87d5-631b7f078989" />
Mobile view:
<img width="344" height="250" alt="Screenshot 2025-10-08 at 1 34 33 PM" src="https://github.com/user-attachments/assets/937a1196-a20a-4e28-9e5f-145b6e6652dd" />

### What is the impact of this change?
Makes mobile nav more functional.

### How was this change tested?
Shrank my browser window and used the mobile menu.

### Was this change documented?
n/a

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
