### PR TITLE
fix: add GH_TOKEN to env for docs build action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,8 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Build documentation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: mkdocs build
 
       - name: Validate links and images
@@ -35,5 +37,5 @@ jobs:
 
       - name: Deploy documentation
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: mkdocs gh-deploy --force


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The docs build failed because it's missing a GH_TOKEN during the build step. (Earlier in the docs development, I had the build step making unauthenticated calls but they got quickly throttled.)

### What was the solution? (How)
Add the GH_TOKEN to the build step.

### What is the impact of this change?
Fixes the GitHub action.

### How was this change tested?
Saw the action succeed in my fork: https://github.com/crowecawcaw/deadline-cloud.github/actions/runs/18357766092

### Was this change documented?
n/a

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
