### PR TITLE
chore: scope down permissions on stale prs workflow

### DIFF
--- a/.github/workflows/reusable_stale_prs_and_issues.yml
+++ b/.github/workflows/reusable_stale_prs_and_issues.yml
@@ -2,6 +2,11 @@ name: 'Check stale issues/PRs.'
 on: 
   workflow_call:
 
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
 jobs:
   stale-review-stage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Scope down permissions of the github token that we pass to actions/stale

### What was the solution? (How)
Set:
```

permissions:
  issues: write
  pull-requests: write
  contents: read
```

### What is the impact of this change?
Scopes down permissions

### How was this change tested?
n/a

### Was this change documented?
n/a

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
