### PR TITLE
ci: extend CodeBuild role duration to 3h

### DIFF
--- a/.github/workflows/reusable_canary.yml
+++ b/.github/workflows/reusable_canary.yml
@@ -38,7 +38,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_CANARY_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
-          role-duration-seconds: 7200
+          role-duration-seconds: 10800
        
       - name: Configure AWS credentials for mainline
         if: ${{inputs.branch == 'mainline'}}
@@ -47,7 +47,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_CANARY_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
-          role-duration-seconds: 7200
+          role-duration-seconds: 10800
         
       - name: Run Canary for Mainline
         if: ${{inputs.branch == 'mainline'}}

--- a/.github/workflows/reusable_e2e_test.yml
+++ b/.github/workflows/reusable_e2e_test.yml
@@ -36,7 +36,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_E2E_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
-          role-duration-seconds: 7200
+          role-duration-seconds: 10800
        
       - name: Configure AWS credentials for mainline
         if: ${{inputs.environment == 'mainline'}}
@@ -45,7 +45,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_E2E_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
-          role-duration-seconds: 7200
+          role-duration-seconds: 10800
         
       - name: Run E2E Tests
         uses: aws-actions/aws-codebuild-run-build@v1


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We're extending worker agent E2E tests to 3h to recent accommodate test coverage additions. 

### What was the solution? (How)
Increase CodeBuild duration to match.

### What is the impact of this change?
CodeBuild test run having valid credentials throughout the test run.

### How was this change tested?
Will be tested in CI

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
