### PR TITLE
ci: add release environment conditions for build installer workflow f…

### DIFF
--- a/.github/workflows/reusable_build_installers.yml
+++ b/.github/workflows/reusable_build_installers.yml
@@ -41,8 +41,8 @@ jobs:
           mask-aws-account-id: true
           role-duration-seconds: 3600
         
-      - name: Build Installer Manual
-        if: github.workflow == 'Build Installers'
+      - name: Build Installer Manual (Non-Release)
+        if: github.workflow == 'Build Installers' && inputs.environment != 'release'
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
           project-name: ${{inputs.project_name}}-${{matrix.os}}Installer
@@ -50,8 +50,16 @@ jobs:
           hide-cloudwatch-logs: true
           artifacts-type-override: NO_ARTIFACTS
 
+      - name: Build Installer Manual (Release)
+        if: github.workflow == 'Build Installers' && inputs.environment == 'release'
+        uses: aws-actions/aws-codebuild-run-build@v1
+        with:
+          project-name: ${{inputs.project_name}}-${{matrix.os}}Installer
+          source-version-override: refs/${{inputs.ref_type}}/${{inputs.ref}}
+          hide-cloudwatch-logs: true
+
       - name: Build Installer Release
-        if: github.workflow != 'Build Installers'
+        if: github.workflow != 'Build Installers' && inputs.environment == 'release'
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
           project-name: ${{inputs.project_name}}-${{matrix.os}}Installer


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We may sometimes require rebuilds of the production builds of the installers.

### What was the solution? (How)
Add an option to build the installer manually with Artifiacts. Make sure production builds always require the release deployment environment to enforce approvals

### What is the impact of this change?
Can now build a installer with artifacts via a manual dispatch workflow

### How was this change tested?
Will be tested after merge.

### Was this change documented?

No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
