### PR TITLE
ci: make environment optional and mainline the default

### DIFF
--- a/.github/workflows/reusable_integration_test.yml
+++ b/.github/workflows/reusable_integration_test.yml
@@ -10,8 +10,9 @@ on:
         required: false
         type: string
       environment:
-        required: true
+        required: false
         type: string
+        default: 'mainline'
       os:
         required: true
         type: string


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
the default behaviour when running integration tests should be to use mainline. If other deployment environments are required they can be passed in.

### What was the solution? (How)
change the environment to not required and set `mainline` as the default

### What is the impact of this change?
environment is optional, defaults to mainline.

### How was this change tested?
not required

### Was this change documented?
no

### Is this a breaking change?
no

*delete text starting here*
A breaking change is one that modifies a public contract in some way or otherwise changes functionality of this application in a way
that is not backwards compatible.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
