### PR TITLE
chore: temporary pin virtualenv<21 to fix build

### DIFF
--- a/.github/workflows/reusable_prerelease.yml
+++ b/.github/workflows/reusable_prerelease.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build
         run: |
-          pip install --upgrade hatch
+          pip install --upgrade hatch "virtualenv<21"
           hatch -v build
 
       # A precommit hook into the GitHub Action workflow.

--- a/.github/workflows/reusable_publish.yml
+++ b/.github/workflows/reusable_publish.yml
@@ -102,7 +102,7 @@ jobs:
       # Tag must be made before building so the generated _version.py files have the correct version
       - name: Build
         run: |
-          pip install --upgrade hatch
+          pip install --upgrade hatch "virtualenv<21"
           hatch -v build
 
       # A precommit hook into the GitHub Action workflow.
@@ -210,7 +210,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch
+          pip install --upgrade hatch "virtualenv<21"
           pip install --upgrade twine
 
       - name: Build

--- a/.github/workflows/reusable_publish_v2.yml
+++ b/.github/workflows/reusable_publish_v2.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Build
         run: |
-          pip install --upgrade hatch
+          pip install --upgrade hatch "virtualenv<21"
           hatch -v build
 
       # A precommit hook into the GitHub Action workflow.
@@ -308,7 +308,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch
+          pip install --upgrade hatch "virtualenv<21"
           pip install --upgrade twine
 
       - name: Download

--- a/.github/workflows/reusable_python_build.yml
+++ b/.github/workflows/reusable_python_build.yml
@@ -65,7 +65,7 @@ jobs:
 
     - name: Install Hatch
       run: |
-        pip install --upgrade hatch
+        pip install --upgrade hatch "virtualenv<21"
 
     - name: Run Linting
       run: hatch -v run lint


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

virtualenv 21.0.0 released which is breaking hatch commands. See https://github.com/pypa/hatch/issues/2193

### What was the solution? (How)

Pin virtualenv to <21 for now

### What is the impact of this change?

hatch commands work again

### How was this change tested?

Ran hatch build with virtualenv<21 successfully

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
