### PR TITLE
chore: make virtualenv<21 pin conditional on Python < 3.10

### DIFF
--- a/.github/workflows/reusable_prerelease.yml
+++ b/.github/workflows/reusable_prerelease.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build
         run: |
-          pip install --upgrade hatch "virtualenv<21"
+          pip install --upgrade hatch 'virtualenv<21; python_version < "3.10"'
           hatch -v build
 
       # A precommit hook into the GitHub Action workflow.

--- a/.github/workflows/reusable_publish.yml
+++ b/.github/workflows/reusable_publish.yml
@@ -102,7 +102,7 @@ jobs:
       # Tag must be made before building so the generated _version.py files have the correct version
       - name: Build
         run: |
-          pip install --upgrade hatch "virtualenv<21"
+          pip install --upgrade hatch 'virtualenv<21; python_version < "3.10"'
           hatch -v build
 
       # A precommit hook into the GitHub Action workflow.
@@ -210,7 +210,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch "virtualenv<21"
+          pip install --upgrade hatch 'virtualenv<21; python_version < "3.10"'
           pip install --upgrade twine
 
       - name: Build

--- a/.github/workflows/reusable_publish_v2.yml
+++ b/.github/workflows/reusable_publish_v2.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Build
         run: |
-          pip install --upgrade hatch "virtualenv<21"
+          pip install --upgrade hatch 'virtualenv<21; python_version < "3.10"'
           hatch -v build
 
       # A precommit hook into the GitHub Action workflow.
@@ -308,7 +308,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install --upgrade hatch "virtualenv<21"
+          pip install --upgrade hatch 'virtualenv<21; python_version < "3.10"'
           pip install --upgrade twine
 
       - name: Download

--- a/.github/workflows/reusable_python_build.yml
+++ b/.github/workflows/reusable_python_build.yml
@@ -65,7 +65,7 @@ jobs:
 
     - name: Install Hatch
       run: |
-        pip install --upgrade hatch "virtualenv<21"
+        pip install --upgrade hatch 'virtualenv<21; python_version < "3.10"'
 
     - name: Run Linting
       run: hatch -v run lint


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The temporary pin of `virtualenv<21` was applied globally to fix build issues with Python 3.8. However, this unnecessarily restricts Python 3.10+ from using the latest virtualenv versions, which have important fixes including [hatch v1.16.5](https://github.com/pypa/hatch/releases/tag/hatch-v1.16.5).

### What was the solution? (How)

Use PEP 508 environment markers to conditionally pin `virtualenv<21` only for Python versions less than 3.10:

```bash
pip install --upgrade hatch 'virtualenv<21; python_version < "3.10"'
```

This allows:
- Python 3.8 and 3.9: Use virtualenv<21 (required for compatibility)
- Python 3.10+: Use the latest virtualenv (no restrictions)

### What is the impact of this change?

Build and test workflows for Python 3.10+ will now use the latest compatible version of virtualenv instead of being pinned to versions below 21, while maintaining compatibility with Python 3.8 and 3.9.

### How was this change tested?

Tested via CI workflows across all Python versions.

### Was this change documented?

N/A - Workflow configuration change

### Does this PR introduce new dependencies?

*   [ ] This PR adds one or more new dependency Python packages.
*   [x] This PR does not add any new dependencies.

### Is this a breaking change?

No. This maintains existing behavior for Python 3.8/3.9 while allowing newer virtualenv for Python 3.10+.

### Does this change impact security?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*