### PR TITLE
fix: codeql doesn't have read permissions for private repos

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,5 +13,6 @@ jobs:
     name: Analysis
     uses: ./.github/workflows/reusable_codeql.yml
     permissions:
+      contents: read
       security-events: write
 

--- a/.github/workflows/reusable_codeql.yml
+++ b/.github/workflows/reusable_codeql.yml
@@ -19,6 +19,7 @@ jobs:
     name: Analyze (${{inputs.languages}})
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       # required for all workflows
       security-events: write
     steps:


### PR DESCRIPTION
re-usable workflow needs the ability for the GITHUB_TOKEN to give read permissions so it can checkout private repos.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
