### PR TITLE
feat: add build-python-version output to reusable_tag_release

### DIFF
--- a/.github/workflows/reusable_tag_release.yml
+++ b/.github/workflows/reusable_tag_release.yml
@@ -12,6 +12,9 @@ on:
       tag:
         description: "The validated tag"
         value: ${{ jobs.TagRelease.outputs.tag }}
+      build-python-version:
+        description: "The Python version to use for building and publishing packages"
+        value: "3.13"
 
 jobs:
   TagRelease:


### PR DESCRIPTION
## Summary

Add a centralized `build-python-version` output (`3.13`) to `reusable_tag_release.yml` so that downstream repos can reference it in their `PublishToPyPI` jobs instead of hardcoding the Python version.

## Motivation

`hatchling` 1.29.0 dropped Python 3.9 support (requires `>=3.10`). This broke the `PublishToPyPI` job in repos still using `python-version: '3.9'` — e.g. [deadline-cloud-test-fixtures run #41](https://github.com/aws-deadline/deadline-cloud-test-fixtures/actions/runs/24371131442/job/71176549821).

By centralizing the build Python version here, we can update it in one place when build tools bump their requirements, rather than updating every repo individually.

## Usage

Downstream repos reference it in their `PublishToPyPI` job:
```yaml
python-version: ${{ needs.TagRelease.outputs.build-python-version || '3.13' }}
```

## Repos that need updating

The following repos still have `python-version: '3.9'` in their `PublishToPyPI` job:
- `deadline-cloud-test-fixtures`
- `deadline-cloud-worker-agent`
- `deadline-cloud-for-nuke`
- `deadline-cloud-for-houdini`
- `deadline-cloud-for-3ds-max`
- `deadline-cloud-for-unreal-engine`
- `deadline-cloud-for-vred`