### PR TITLE
feat: add require_approval flag to reusable release workflows

### DIFF
--- a/.github/workflows/reusable_build_and_stage_installers.yml
+++ b/.github/workflows/reusable_build_and_stage_installers.yml
@@ -12,6 +12,10 @@ on:
       project_name:
         required: true
         type: string
+      require_approval:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   BuildInstallers:
@@ -28,7 +32,7 @@ jobs:
   StageBuiltInstallers:
     needs: BuildInstallers
     runs-on: ubuntu-latest
-    environment: release
+    environment: ${{ inputs.require_approval && 'release' || 'release-no-approval-required' }}
     permissions:
       id-token: write
     strategy:

--- a/.github/workflows/reusable_bump.yml
+++ b/.github/workflows/reusable_bump.yml
@@ -7,12 +7,16 @@ on:
       force_version_bump:
         required: false
         default: ""
-        type: string        
+        type: string
+      require_approval:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   Bump:
     runs-on: ubuntu-latest
-    environment: release
+    environment: ${{ inputs.require_approval && 'release' || 'release-no-approval-required' }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/reusable_prerelease.yml
+++ b/.github/workflows/reusable_prerelease.yml
@@ -6,12 +6,16 @@ on:
       tag:
         required: true
         type: string
+      require_approval:
+        required: false
+        type: boolean
+        default: true
 
 
 jobs:
   PreRelease:
     runs-on: ubuntu-latest
-    environment: release
+    environment: ${{ inputs.require_approval && 'release' || 'release-no-approval-required' }}
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/reusable_publish.yml
+++ b/.github/workflows/reusable_publish.yml
@@ -2,6 +2,11 @@ name: 'Publish'
 
 on:
   workflow_call:
+    inputs:
+      require_approval:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   VerifyCommit:
@@ -29,7 +34,7 @@ jobs:
   Release:
     needs: VerifyCommit
     runs-on: ubuntu-latest
-    environment: release
+    environment: ${{ inputs.require_approval && 'release' || 'release-no-approval-required' }}
     permissions:
       id-token: write
       contents: write
@@ -158,7 +163,7 @@ jobs:
   PublishToInternal:
     needs: Release
     runs-on: ubuntu-latest
-    environment: release
+    environment: ${{ inputs.require_approval && 'release' || 'release-no-approval-required' }}
     permissions:
       id-token: write
     steps:
@@ -178,7 +183,7 @@ jobs:
   PublishToRepository:
     needs: PublishToInternal
     runs-on: ubuntu-latest
-    environment: release
+    environment: ${{ inputs.require_approval && 'release' || 'release-no-approval-required' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/reusable_publish_python.yml
+++ b/.github/workflows/reusable_publish_python.yml
@@ -6,11 +6,15 @@ on:
       tag:
         required: true
         type: string
-        
+      require_approval:
+        required: false
+        type: boolean
+        default: true
+
 jobs:
   PublishToCodeArtifact:
     runs-on: ubuntu-latest
-    environment: release
+    environment: ${{ inputs.require_approval && 'release' || 'release-no-approval-required' }}
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/reusable_publish_v2.yml
+++ b/.github/workflows/reusable_publish_v2.yml
@@ -14,6 +14,10 @@ on:
       installer_oses:
         required: false
         type: string
+      require_approval:
+        required: false
+        type: boolean
+        default: true
     outputs:
       tag:
         description: "The newly created tag"
@@ -59,7 +63,7 @@ jobs:
   PreRelease:
     needs: UnitTests
     runs-on: ubuntu-latest
-    environment: release
+    environment: ${{ inputs.require_approval && 'release' || 'release-no-approval-required' }}
     outputs: 
       tag: ${{steps.prep-release.outputs.TAG}}
     permissions:
@@ -147,7 +151,7 @@ jobs:
     needs: BuildInstallers
     if: needs.BuildInstallers.result == 'success' || needs.BuildInstallers.result == 'skipped'
     runs-on: ubuntu-latest
-    environment: release
+    environment: ${{ inputs.require_approval && 'release' || 'release-no-approval-required' }}
     name: “Is the Conda Package available in all ProdWaves and have you ran any required manual tests?”
     steps:
       - run: |
@@ -161,7 +165,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    environment: release
+    environment: ${{ inputs.require_approval && 'release' || 'release-no-approval-required' }}
     env:
       TAG: ${{needs.PreRelease.outputs.tag}}
     steps:
@@ -219,7 +223,7 @@ jobs:
   ReleaseBuiltInstallers:
     needs: [Release, PreRelease]
     runs-on: ubuntu-latest
-    environment: release
+    environment: ${{ inputs.require_approval && 'release' || 'release-no-approval-required' }}
     if: (needs.Release.result == 'success' && needs.PreRelease.result == 'success') && ${{ inputs.installer_oses }} 
     permissions:
       id-token: write
@@ -251,7 +255,7 @@ jobs:
     needs: [ReleaseBuiltInstallers, PreRelease]
     if: (needs.ReleaseBuiltInstallers.result == 'success' && needs.PreRelease.result == 'success')
     runs-on: ubuntu-latest
-    environment: release
+    environment: ${{ inputs.require_approval && 'release' || 'release-no-approval-required' }}
     permissions:
       id-token: write
     env:
@@ -275,7 +279,7 @@ jobs:
     needs: [PublishToInternal, PreRelease]
     if: (needs.PublishToInternal.result == 'success' && needs.PreRelease.result == 'success')
     runs-on: ubuntu-latest
-    environment: release
+    environment: ${{ inputs.require_approval && 'release' || 'release-no-approval-required' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/reusable_release.yml
+++ b/.github/workflows/reusable_release.yml
@@ -6,6 +6,10 @@ on:
       tag:
         required: true
         type: string
+      require_approval:
+        required: false
+        type: boolean
+        default: true
 
 
 jobs:
@@ -15,7 +19,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    environment: release
+    environment: ${{ inputs.require_approval && 'release' || 'release-no-approval-required' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/reusable_release_installers.yml
+++ b/.github/workflows/reusable_release_installers.yml
@@ -10,11 +10,15 @@ on:
       project_name:
         required: true
         type: string
+      require_approval:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   ReleaseInstaller:
     runs-on: ubuntu-latest
-    environment: release
+    environment: ${{ inputs.require_approval && 'release' || 'release-no-approval-required' }}
     permissions:
       id-token: write
     strategy:

--- a/.github/workflows/reusable_tag_release.yml
+++ b/.github/workflows/reusable_tag_release.yml
@@ -8,6 +8,10 @@ on:
         required: false
         type: string
         description: "Existing tag to use (optional)"
+      require_approval:
+        required: false
+        type: boolean
+        default: true
     outputs:
       tag:
         description: "The validated tag"
@@ -19,7 +23,7 @@ on:
 jobs:
   TagRelease:
     runs-on: ubuntu-latest
-    environment: release
+    environment: ${{ inputs.require_approval && 'release' || 'release-no-approval-required' }}
     outputs:
       tag: ${{ steps.tag-release.outputs.tag }}
     steps:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Releases require many approval steps that are not necesasary (though a few still are).

### What was the solution? (How)
Add a `require_approval` boolean input (default: true) to all reusable workflows that use `environment: release` purely for gating and secrets access. When false, the workflow uses a `release-no-approval-required` environment that has the same secrets but no required reviewers.

This allows consuming repos to skip manual approval clicks for steps that don't need them, while keeping a single approval gate for manual testing.

Workflows that use the environment name semantically (integration_test, e2e_test, build_installers) are not changed, since the environment name is used for AWS role selection and CodeBuild project names.

Affected workflows:
- reusable_bump.yml
- reusable_tag_release.yml
- reusable_prerelease.yml
- reusable_release.yml
- reusable_publish.yml
- reusable_publish_python.yml
- reusable_publish_v2.yml
- reusable_release_installers.yml
- reusable_build_and_stage_installers.yml

Prerequisites: A `release-no-approval-required` environment must be created in each consuming repo's GitHub settings with the same secrets as `release` but no required reviewers.

### What is the impact of this change?
Enables us to remove some manual button clicking.

### How was this change tested?
Not tested yet.

### Was this change documented?
n/a

### Is this a breaking change?
No. Workflows default to the current enviroments.


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
