### PR TITLE
ci: add pip and hatch environment caching to reusable python build

### DIFF
--- a/.github/workflows/reusable_python_build.yml
+++ b/.github/workflows/reusable_python_build.yml
@@ -1,3 +1,9 @@
+# Caching strategy:
+# - pip download cache and hatch virtualenv cache are always enabled.
+# - The cache key includes OS, Python version, and hashes of all dependency files so it
+#   auto-busts when deps change.
+# - Release artifacts (PyPI packages, installers) are built in separate jobs with clean
+#   environments, so the cache does not affect published artifacts.
 name: Python Build
 
 on:
@@ -28,6 +34,7 @@ jobs:
     env:
       PYTHON: ${{ inputs.python-version }}
       PY_COLORS: 1
+      HATCH_DATA_DIR: ${{ github.workspace }}/.hatch-data
     steps:
     - uses: actions/checkout@v4
       if: ${{ !inputs.branch && !inputs.commit && !inputs.ref }}
@@ -47,7 +54,7 @@ jobs:
       if: ${{ inputs.ref }}
       with:
         ref: ${{ inputs.ref }}
-      
+
     - name: setup ${{ inputs.os }}
       if: inputs.os == 'ubuntu-latest'
       run: |
@@ -56,12 +63,18 @@ jobs:
           libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 \
           libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 \
           x11-utils libxcb-cursor0 libopengl0
-        
 
     - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
+        cache: pip
+
+    - name: Restore Hatch environment cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/.hatch-data/env
+        key: hatch-env-${{ inputs.os }}-py${{ inputs.python-version }}-${{ hashFiles('pyproject.toml', 'hatch.toml', 'requirements*.txt') }}
 
     - name: Install Hatch
       run: |


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
CI builds spent about half their time downloading dependencies and setting up environments.

### What was the solution? (How)
Add cache: pip to setup-python for pip download caching. Add actions/cache for the full hatch virtualenv environment, keyed on OS, python version, and dependency file hashes. Uses HATCH_DATA_DIR to normalize the env path across platforms.

Release artifacts (PyPI packages, installers) are built in separate jobs with clean environments, so the cache does not affect published artifacts.

### What is the impact of this change?
Faster builds

Tested on crowecawcaw/deadline-cloud PR #1 (3 OS × 7 Python versions = 24 jobs)
```
                      Cold Cache    Warm Cache    Savings
  ubuntu (avg)          2m57s         2m44s        ~7%
  macos (avg)           2m53s         2m23s       ~17%
  windows (avg)         5m50s         4m26s       ~24%

  Biggest wins:
    windows-latest 3.12    7m10s → 3m59s   (44%)
    macos-latest   3.13    3m08s → 1m40s   (47%)
    macos-latest   3.11    2m34s → 1m30s   (42%)
```
### How was this change tested?
Tested in my fork, above.

### Was this change documented?
n/a

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
