### PR TITLE
docs: add deadline-cloud-job-attachments to service clients table

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -26,6 +26,7 @@ This GitHub org has integrations (such as job submission plugins) for a selectio
 | - | - |
 | [deadline-cloud](https://github.com/aws-deadline/deadline-cloud) | A Python CLI and library for interacting with Deadline Cloud, especially submitting jobs. |
 | [deadline-cloud-samples](https://github.com/aws-deadline/deadline-cloud-samples) | Example code and tools for running workloads on Deadline Cloud. |
+| [deadline-cloud-job-attachments](https://github.com/aws-deadline/deadline-cloud-job-attachments) | A Python library for Deadline Cloud Job Attachments related functionality. |
 | [deadline-cloud-worker-agent](https://github.com/aws-deadline/deadline-cloud-worker-agent) | Software that runs on workers and communicates with the Deadline Cloud API for receiving and completing tasks. |
 
 ## FAQ


### PR DESCRIPTION
Fixes: https://github.com/aws-deadline/.github/issues/<ISSUE_NUMBER>

### What was the problem/requirement? (What/Why)

The `deadline-cloud-job-attachments` repository was missing from the "Service clients and sample repositories" table in the organization's profile README.

### What was the solution? (How)

Added an entry for `deadline-cloud-job-attachments` to the service clients table in `profile/README.md`, describing it as a Python library for Deadline Cloud Job Attachments related functionality.

### What is the impact of this change?

Improves discoverability of the job attachments library for users browsing the GitHub org profile.

### How was this change tested?

Verified the markdown table renders correctly.

### Was this change documented?

This change is itself a documentation update.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
