### PR TITLE
fix: include Python patch version in Hatch env cache key

### DIFF
--- a/.github/workflows/reusable_python_build.yml
+++ b/.github/workflows/reusable_python_build.yml
@@ -65,6 +65,7 @@ jobs:
           x11-utils libxcb-cursor0 libopengl0
 
     - name: Set up Python ${{ inputs.python-version }}
+      id: setup-python
       uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
@@ -74,7 +75,11 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/.hatch-data/env
-        key: hatch-env-${{ inputs.os }}-py${{ inputs.python-version }}-${{ hashFiles('pyproject.toml', 'hatch.toml', 'requirements*.txt') }}
+        # Include the full patch version so the cache busts when the runner image
+        # rolls to a new patch (e.g. 3.14.4 -> 3.14.5). Otherwise the cached venv's
+        # console-script shebangs point at a removed interpreter and tools like
+        # mypy fail with "command not found".
+        key: hatch-env-${{ inputs.os }}-py${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('pyproject.toml', 'hatch.toml', 'requirements*.txt') }}
 
     - name: Install Hatch
       run: |


### PR DESCRIPTION
## Summary
- The Hatch virtualenv cache key currently uses `inputs.python-version` (e.g. `3.14`), which is the major.minor that consumers pass in.
- When the GitHub-hosted runner image rolls to a new Python patch (e.g. `3.14.4` → `3.14.5`), the cache still hits but the cached venv's console-script shebangs reference the removed `/opt/hostedtoolcache/Python/3.14.4/...` interpreter. `ruff` works (it's a single static binary), but `mypy` and any other entry-point script fails with `mypy: not found`.
- Fix: include the resolved patch version (`steps.setup-python.outputs.python-version`) in the cache key so it auto-busts on patch upgrades.

## Repro
[aws-deadline/deadline-cloud#1174](https://github.com/aws-deadline/deadline-cloud/pull/1174), Python (ubuntu-latest, 3.14) lint job ([run 26042492593](https://github.com/aws-deadline/deadline-cloud/actions/runs/26042492593/job/76608368140)):

```
Cache hit for: hatch-env-ubuntu-latest-py3.14-b38f224010cfe769e22f016fa04a889fee2a21a12011a6adb15e5a2e2382434e
Successfully set up CPython (3.14.5)
...
cmd [1] | ruff check .              # ok
cmd [2] | ruff format --check ...   # ok
cmd [3] | mypy src test ...
/bin/sh: 1: mypy: not found
##[error]Process completed with exit code 127.
```

The last successful mainline run ([2026-05-13](https://github.com/aws-deadline/deadline-cloud/actions/runs/25827896147)) populated this cache key on Python 3.14.4. PRs since then are inheriting it on 3.14.5.

## Test plan
- [ ] Merge and re-run the failing job in deadline-cloud#1174; expect a cache miss on the new key (`...-py3.14.5-...`), env rebuild, and lint to pass.
- [ ] Subsequent runs on the same patch version hit the cache and run normally.