### PR TITLE
fix: resolve fork PRs in Claude review by querying the head repo

### DIFF
--- a/.github/workflows/reusable_claude_pr_review.yml
+++ b/.github/workflows/reusable_claude_pr_review.yml
@@ -87,10 +87,17 @@ jobs:
           set -euo pipefail
           [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::bad head_sha"; exit 1; }
 
-          # "List pull requests associated with a commit" spans the repo's fork
-          # network. Filter to open PRs whose head repo matches the trusted one.
-          matches=$(gh api "repos/$REPO/commits/$HEAD_SHA/pulls" \
-            --jq "[.[] | select(.state == \"open\" and .head.repo.full_name == \"$EXPECTED_HEAD_REPO\")]")
+          # "List pull requests associated with a commit" only reliably returns
+          # PRs whose head commit lives in the queried repo. For a fork PR the
+          # head commit lives in the fork, not the base repo, so querying $REPO
+          # returns nothing -- query the trusted head repo instead. We then pin
+          # the base repo back to $REPO so the resolved PR is guaranteed to
+          # target this repository (the comment target cannot be redirected to a
+          # PR in some other base), and keep only open PRs from the trusted head
+          # repo. Both $EXPECTED_HEAD_REPO and $HEAD_SHA come from the
+          # server-populated workflow_run payload and cannot be forged.
+          matches=$(gh api "repos/$EXPECTED_HEAD_REPO/commits/$HEAD_SHA/pulls" \
+            --jq "[.[] | select(.state == \"open\" and .head.repo.full_name == \"$EXPECTED_HEAD_REPO\" and .base.repo.full_name == \"$REPO\")]")
 
           count=$(echo "$matches" | jq 'length')
           if [[ "$count" -ne 1 ]]; then


### PR DESCRIPTION
The Claude PR review **"Resolve and validate PR from trusted head SHA"** step fails for every PR that comes from a fork, which is essentially every external contributor PR.

## Symptom

The review job fails at the resolve step with:

```
expected exactly 1 open PR for 727eea59fb34ba36b8514ae41ead961b755f0995 from crowecawcaw/deadline-cloud, found 0
```

(Example: [deadline-cloud run 27216902742](https://github.com/aws-deadline/deadline-cloud/actions/runs/27216902742/job/80364011946), for the open PR [aws-deadline/deadline-cloud#1201](https://github.com/aws-deadline/deadline-cloud/pull/1201).)

## Root cause

The step queried `repos/$REPO/commits/$HEAD_SHA/pulls` against the **base** repo. Despite the docs claiming this endpoint spans the fork network, in practice it only reliably returns PRs whose **head commit lives in the queried repo**. For a fork PR the head commit lives in the fork, so the base-repo query returns `[]` → `found 0` → `exit 1`.

Verified against PR #1201 (head `727eea5…`):

| Query repo | Result |
|---|---|
| `aws-deadline/deadline-cloud/commits/727eea5/pulls` (base) | `[]` ❌ |
| `crowecawcaw/deadline-cloud/commits/727eea5/pulls` (head/fork) | returns #1201 ✅ |
| `aws-deadline/deadline-cloud/commits/<sha>/pulls` (a same-repo PR) | returns the PR ✅ |

So review worked only for same-repo branch PRs and silently failed for all fork PRs.

## Fix

Query the **trusted head repo** (`$EXPECTED_HEAD_REPO`, from the `workflow_run` payload) for the commits→pulls lookup, and add a `.base.repo.full_name == $REPO` filter so the resolved PR is still guaranteed to target this repository.

## Security

Unchanged. Both `head_repository` and `head_sha` come only from the server-populated `workflow_run` event payload and cannot be forged by a fork. The new `.base.repo.full_name == $REPO` filter ensures the comment target is a PR that actually targets this base repo, so it cannot be redirected to a PR in some other base. The `state == "open"` + exactly-one-match (fail-closed) guarantees are preserved.

## Verification

With the new query, PR #1201 resolves to `count: 1, pr_number: 1201` with the correct base SHA.