### PR TITLE
fix: check out tooling repo so Claude review installs pinned requirements

### DIFF
--- a/.github/workflows/reusable_claude_pr_review.yml
+++ b/.github/workflows/reusable_claude_pr_review.yml
@@ -44,6 +44,16 @@ on:
         required: false
         type: number
         default: 20
+      tooling_repository:
+        description: "Repo holding this workflow's pinned requirements file. A reusable workflow does not check out its own repo, so the caller names it here. Defaults to the workflow's home repo; overridden only for fork testing."
+        required: false
+        type: string
+        default: "aws-deadline/.github"
+      tooling_ref:
+        description: "Ref of tooling_repository to check the requirements file out from. Defaults to mainline, matching the @mainline reference callers use for this workflow."
+        required: false
+        type: string
+        default: "mainline"
     secrets:
       bedrock_role_arn:
         description: "ARN of the OIDC role that can mint a Bedrock bearer token. Kept in a secret so the account id is configured in one place."
@@ -140,6 +150,22 @@ jobs:
           BASE_SHA: ${{ steps.meta.outputs.base_sha }}
         run: git fetch --depth=1 origin "$BASE_SHA"
 
+      # A reusable workflow does not check out its own repository -- the only
+      # checkout above is the PR head under pr-head/. So the pinned requirements
+      # file that lives alongside this workflow is not on disk. Check out the
+      # tooling repo (this workflow's home repo by default; see tooling_repository
+      # / tooling_ref inputs) into workflow-tooling/ so the install step below can
+      # read the version-pinned requirements file. persist-credentials is false
+      # so no token is left on disk.
+      - name: Check out workflow tooling (pinned requirements)
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.tooling_repository }}
+          ref: ${{ inputs.tooling_ref }}
+          path: workflow-tooling
+          persist-credentials: false
+          submodules: false
+
       # Install the token generator BEFORE any AWS credentials exist in the
       # environment. Even though the package is version-pinned (see
       # claude-review-requirements.txt), running its install with no IAM session
@@ -149,7 +175,7 @@ jobs:
         run: |
           set -euo pipefail
           python3 -m pip install --quiet --only-binary :all: \
-            -r .github/workflows/claude-review-requirements.txt
+            -r workflow-tooling/.github/workflows/claude-review-requirements.txt
 
       # Assume the OIDC role and mint a Bedrock bearer token in a step that holds
       # the IAM credentials, then unset those credentials before the agent runs.


### PR DESCRIPTION
Follow-up to #82. With the fork-PR resolve fix merged, the Claude review job reaches the next step and fails:

```
ERROR: Could not open requirements file: [Errno 2] No such file or directory:
.github/workflows/claude-review-requirements.txt
```

## Cause

A reusable workflow does **not** check out its own repository — the only checkout is the PR head into `pr-head/`. The pinned `claude-review-requirements.txt` lives here in `aws-deadline/.github` and is therefore never on disk, so `pip install -r .github/workflows/claude-review-requirements.txt` fails.

## Fix

Add `tooling_repository` / `tooling_ref` inputs (defaulting to `aws-deadline/.github` @ `mainline`, matching how callers reference this workflow via `@mainline`) and check that repo out into `workflow-tooling/`, then install from there. This keeps the version pin and the `pip` Dependabot watcher intact rather than inlining the version.

Production callers need no change — they get the defaults. The inputs exist so the path can be overridden (e.g. fork testing).

## Security

Unchanged. The tooling checkout uses `persist-credentials: false`, and the install still runs **before** any AWS credentials exist in the environment, with `--only-binary :all:` blocking arbitrary `setup.py` execution. No PR-controlled input affects what is installed.

## Verification

Tested end-to-end in a fork (thin callers → reusable workflow, with `tooling_repository`/`tooling_ref` overridden to the fork branch). Full two-stage flow ran green: resolve → PR-head checkout → **tooling checkout → token-generator install** → OIDC mint → Claude review.

- ✅ Successful review run: https://github.com/crowecawcaw/deadline-cloud/actions/runs/27222705210
- ✅ Review comment Claude posted on the test PR: https://github.com/crowecawcaw/deadline-cloud/pull/14#issuecomment-4662132327

Note: an earlier iteration used `github.job_workflow_ref` to derive the repo automatically; fork testing showed that context property is empty for reusable workflows, so this uses explicit inputs instead.
