### PR TITLE
fix: pass GITHUB_TOKEN to claude-code-action so it skips the Claude App

### DIFF
--- a/.github/workflows/reusable_claude_pr_review.yml
+++ b/.github/workflows/reusable_claude_pr_review.yml
@@ -215,6 +215,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           use_bedrock: "true"
+          # Use the workflow's GITHUB_TOKEN (scoped pull-requests/issues: write by
+          # the caller) for the action's own GitHub calls. Without this the action
+          # falls back to minting a Claude GitHub App installation token, which 401s
+          # ("Claude Code is not installed on this repository") since this design
+          # deliberately does not install that app.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             You are an automated, advisory code reviewer for a public AWS
             Deadline Cloud open-source repository. Review ONLY the changes in


### PR DESCRIPTION
The Claude PR review step fails with:

```
App token exchange failed: 401 Unauthorized -
Claude Code is not installed on this repository.
Please install the Claude Code GitHub App at https://github.com/apps/claude
##[error]Action failed with error: Claude Code is not installed on this repository.
```

(seen in [deadline-cloud run 27288737570](https://github.com/aws-deadline/deadline-cloud/actions/runs/27288737570/job/80604585787) — the OIDC role assume and Bedrock token minting now succeed; this is the next step that fails.)

## Cause

`anthropics/claude-code-action` authenticates to GitHub one of two ways:

1. with the `github_token` **input** if provided, or
2. otherwise by exchanging its own OIDC token for a **Claude GitHub App** installation token.

This workflow only set `GH_TOKEN` in the step **env** — which the agent uses for its `gh api` comment tool — but never passed the action the `github_token` **input**. So the action fell back to path 2 and 401'd, because the Claude App is not installed on these public repos (and, per this workflow's self-contained Bedrock design, should not be).

## Fix

Pass the workflow's `GITHUB_TOKEN` as the `github_token` input. The caller already grants `pull-requests: write` and `issues: write`, so the action can post review comments using the built-in token — no Claude App and no new secret required.

One-line change (plus an explanatory comment) in the `with:` block of the `Claude PR review` step.
