### PR TITLE
fix: pass GitHub event context via env vars in reusable workflows

### DIFF
--- a/.github/workflows/reusable_bump.yml
+++ b/.github/workflows/reusable_bump.yml
@@ -74,9 +74,11 @@ jobs:
           git checkout -b bump/$NEXT_SEMVER
 
       - name: GenerateChangeLog
+        env:
+          REPO_NAME: ${{ github.event.repository.name }}
         run: |
           PREV_TAG=$(git describe --tags --abbrev=0)
-          NOTES=$(python .dot-github/.github/scripts/generate_release_notes.py "$NEXT_SEMVER" --since "$PREV_TAG" --repo "${{ github.event.repository.name }}")
+          NOTES=$(python .dot-github/.github/scripts/generate_release_notes.py "$NEXT_SEMVER" --since "$PREV_TAG" --repo "$REPO_NAME")
 
           # Prepend new release notes to the original changelog
           echo "$NOTES" > NEW_LOG.md

--- a/.github/workflows/reusable_record_pr_details.yml
+++ b/.github/workflows/reusable_record_pr_details.yml
@@ -15,10 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create PR info artifact
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_ACTION: ${{ github.event.action }}
         run: |
           mkdir -p ./pr-info
-          echo "${{ github.event.pull_request.number }}" > ./pr-info/pr-number.txt
-          echo "${{ github.event.action }}" > ./pr-info/pr-action.txt
+          echo "$PR_NUMBER" > ./pr-info/pr-number.txt
+          echo "$PR_ACTION" > ./pr-info/pr-action.txt
       
       - name: Upload PR info artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Some github event data is interpolated into inline scripts.

### What was the solution? (How)
Move `github.event.*` interpolations (pull_request.number, event.action, repository.name) out of inline run: scripts and into env: blocks so they are referenced as shell variables rather than templated into script text.

### What is the impact of this change?
Avoids possibility of some script injections. Not really an issue for this particular use case, but can trip up security scanners.

### How was this change tested?
Triggered an action that uses this mechanism in my fork: https://github.com/crowecawcaw/deadline-cloud.github/actions/runs/28263554472/job/83744704079

### Was this change documented?
n/a

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
