### PR TITLE
ci: add reusable Security Scan workflow (zizmor) and pin actions to SHAs

### DIFF
--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -13,7 +13,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         ref: refs/tags/${{ inputs.tag }}
         fetch-depth: 0

--- a/.github/workflows/reusable_build_and_stage_installers.yml
+++ b/.github/workflows/reusable_build_and_stage_installers.yml
@@ -36,13 +36,13 @@ jobs:
         os: ${{ fromJson(inputs.oses) }}    
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_INSTALLER_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
       - name: Run CodeBuild
-        uses: aws-actions/aws-codebuild-run-build@v1
+        uses: aws-actions/aws-codebuild-run-build@7e46c3fa1c1f217e26a73712796b1f78938b534b # v1.0.18
         with:
           project-name: ReleaseInstallerProject
           hide-cloudwatch-logs: true

--- a/.github/workflows/reusable_build_installers.yml
+++ b/.github/workflows/reusable_build_installers.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_INSTALLER_ROLE }}
           aws-region: us-west-2
@@ -43,7 +43,7 @@ jobs:
         
       - name: Build Installer Manual (Non-Release)
         if: github.workflow == 'Build Installers' && inputs.environment != 'release'
-        uses: aws-actions/aws-codebuild-run-build@v1
+        uses: aws-actions/aws-codebuild-run-build@7e46c3fa1c1f217e26a73712796b1f78938b534b # v1.0.18
         with:
           project-name: ${{inputs.project_name}}-${{matrix.os}}Installer
           source-version-override: refs/${{inputs.ref_type}}/${{inputs.ref}}
@@ -52,7 +52,7 @@ jobs:
 
       - name: Build Installer Manual (Release)
         if: github.workflow == 'Build Installers' && inputs.environment == 'release'
-        uses: aws-actions/aws-codebuild-run-build@v1
+        uses: aws-actions/aws-codebuild-run-build@7e46c3fa1c1f217e26a73712796b1f78938b534b # v1.0.18
         with:
           project-name: ${{inputs.project_name}}-${{matrix.os}}Installer
           source-version-override: refs/${{inputs.ref_type}}/${{inputs.ref}}
@@ -60,7 +60,7 @@ jobs:
 
       - name: Build Installer Release
         if: github.workflow != 'Build Installers' && inputs.environment == 'release'
-        uses: aws-actions/aws-codebuild-run-build@v1
+        uses: aws-actions/aws-codebuild-run-build@7e46c3fa1c1f217e26a73712796b1f78938b534b # v1.0.18
         with:
           project-name: ${{inputs.project_name}}-${{matrix.os}}Installer
           source-version-override: refs/${{inputs.ref_type}}/${{inputs.ref}}

--- a/.github/workflows/reusable_bump.yml
+++ b/.github/workflows/reusable_bump.yml
@@ -19,14 +19,14 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 0
           token: ${{ secrets.CI_TOKEN }}
 
       - name: Checkout release notes script
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: aws-deadline/.github
           ref: mainline
@@ -34,7 +34,7 @@ jobs:
           sparse-checkout: .github/scripts/generate_release_notes.py
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.13'
 
@@ -47,7 +47,7 @@ jobs:
           git config --local user.name ${{secrets.USER}}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_PGP_KEY_SECRET_ROLE }}
           aws-region: us-west-2

--- a/.github/workflows/reusable_canary.yml
+++ b/.github/workflows/reusable_canary.yml
@@ -26,14 +26,14 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         if: ${{inputs.branch == 'mainline' || inputs.branch == 'release'}}
         with:
           ref: ${{inputs.branch}}
           
       - name: Configure AWS credentials for release
         if: ${{inputs.branch == 'release'}}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_CANARY_ROLE }}
           aws-region: us-west-2
@@ -42,7 +42,7 @@ jobs:
        
       - name: Configure AWS credentials for mainline
         if: ${{inputs.branch == 'mainline'}}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_CANARY_ROLE }}
           aws-region: us-west-2
@@ -51,7 +51,7 @@ jobs:
         
       - name: Run Canary for Mainline
         if: ${{inputs.branch == 'mainline'}}
-        uses: aws-actions/aws-codebuild-run-build@v1
+        uses: aws-actions/aws-codebuild-run-build@7e46c3fa1c1f217e26a73712796b1f78938b534b # v1.0.18
         with:
           project-name: ${{inputs.repository}}-${{inputs.branch}}-${{inputs.os}}-canary
           hide-cloudwatch-logs: true
@@ -64,7 +64,7 @@ jobs:
 
       - name: Run Canary for Release
         if: ${{inputs.branch == 'release'}}
-        uses: aws-actions/aws-codebuild-run-build@v1
+        uses: aws-actions/aws-codebuild-run-build@7e46c3fa1c1f217e26a73712796b1f78938b534b # v1.0.18
         with:
           project-name: ${{inputs.repository}}-${{inputs.branch}}-${{inputs.os}}-canary
           source-version-override: refs/heads/release

--- a/.github/workflows/reusable_claude_pr_review.yml
+++ b/.github/workflows/reusable_claude_pr_review.yml
@@ -200,7 +200,7 @@ jobs:
       # is false so no token is left on disk, submodules are not fetched, and the
       # repo root is left untouched. The agent reads pr-head/ but never runs it.
       - name: Checkout PR head (read-only)
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
         with:
           repository: ${{ inputs.head_repository }}
           ref: ${{ steps.meta.outputs.head_sha }}
@@ -230,7 +230,7 @@ jobs:
       # read the version-pinned requirements file. persist-credentials is false
       # so no token is left on disk.
       - name: Check out workflow tooling (pinned requirements)
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.0
         with:
           repository: ${{ inputs.tooling_repository }}
           ref: ${{ inputs.tooling_ref }}
@@ -253,7 +253,7 @@ jobs:
       # the IAM credentials, then unset those credentials before the agent runs.
       # role-duration-seconds bounds the token's lifetime to about an hour.
       - name: Configure AWS credentials (OIDC, mint scope only)
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.0.0
         with:
           role-to-assume: ${{ secrets.bedrock_role_arn }}
           aws-region: ${{ inputs.aws_region }}

--- a/.github/workflows/reusable_codeql.yml
+++ b/.github/workflows/reusable_codeql.yml
@@ -23,15 +23,15 @@ jobs:
       security-events: write
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     
      # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3.36.3
       with:
         queries: +security-and-quality
         languages: ${{inputs.languages}}
         build-mode: ${{inputs.mode }}
     
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3.36.3

--- a/.github/workflows/reusable_e2e_test.yml
+++ b/.github/workflows/reusable_e2e_test.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Configure AWS credentials for release
         if: ${{inputs.environment == 'release'}}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_E2E_ROLE }}
           aws-region: us-west-2
@@ -40,7 +40,7 @@ jobs:
        
       - name: Configure AWS credentials for mainline
         if: ${{inputs.environment == 'mainline'}}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_E2E_ROLE }}
           aws-region: us-west-2
@@ -48,7 +48,7 @@ jobs:
           role-duration-seconds: 10800
         
       - name: Run E2E Tests
-        uses: aws-actions/aws-codebuild-run-build@v1
+        uses: aws-actions/aws-codebuild-run-build@7e46c3fa1c1f217e26a73712796b1f78938b534b # v1.0.18
         with:
           project-name: ${{inputs.repository}}-${{inputs.environment}}-${{inputs.os}}-e2e
           hide-cloudwatch-logs: true

--- a/.github/workflows/reusable_extract_pr_details.yml
+++ b/.github/workflows/reusable_extract_pr_details.yml
@@ -35,7 +35,7 @@ jobs:
       pr_action: ${{ steps.extract-pr-details.outputs.pr_action }}
     steps:
       - name: Download PR artifact
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         env:
           WORKFLOW_ID: ${{ inputs.record_pr_workflow_id }}
           ARTIFACT_NAME: ${{ inputs.artifact_name }}

--- a/.github/workflows/reusable_integration_test.yml
+++ b/.github/workflows/reusable_integration_test.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Configure AWS credentials for release
         if: ${{inputs.environment == 'release'}}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_INTEG_ROLE }}
           aws-region: us-west-2
@@ -40,14 +40,14 @@ jobs:
        
       - name: Configure AWS credentials for mainline
         if: ${{inputs.environment == 'mainline'}}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_INTEG_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
         
       - name: Run Integration Tests
-        uses: aws-actions/aws-codebuild-run-build@v1
+        uses: aws-actions/aws-codebuild-run-build@7e46c3fa1c1f217e26a73712796b1f78938b534b # v1.0.18
         with:
           project-name: ${{inputs.repository}}-${{inputs.environment}}-${{inputs.os}}-integ
           hide-cloudwatch-logs: true

--- a/.github/workflows/reusable_prerelease.yml
+++ b/.github/workflows/reusable_prerelease.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: refs/tags/${{inputs.tag}}
           fetch-depth: 0
@@ -45,7 +45,7 @@ jobs:
           tag: ${{ inputs.tag }}
 
       - name: UploadArtifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: build-artifact
           path: |

--- a/.github/workflows/reusable_publish.yml
+++ b/.github/workflows/reusable_publish.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
@@ -35,21 +35,21 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: release
           fetch-depth: 0
           token: ${{ secrets.CI_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.9'
 
       # Use CodeArtifact to so that any dependencies we package up in the PrePushReleaseHook
       # are from an internal repository.
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
           aws-region: us-west-2
@@ -122,7 +122,7 @@ jobs:
           tag: ${{ env.TAG }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_PGP_KEY_SECRET_ROLE }}
           aws-region: us-west-2
@@ -163,14 +163,14 @@ jobs:
       id-token: write
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_PUBLISH_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
 
       - name: Run CodeBuild
-        uses: aws-actions/aws-codebuild-run-build@v1
+        uses: aws-actions/aws-codebuild-run-build@7e46c3fa1c1f217e26a73712796b1f78938b534b # v1.0.18
         with:
           project-name: ${{ github.event.repository.name }}-release-Publish
           hide-cloudwatch-logs: true
@@ -191,20 +191,20 @@ jobs:
       CUSTOMER_REPOSITORY: ${{ secrets.CUSTOMER_REPOSITORY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: release
           fetch-depth: 0
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.9'
 

--- a/.github/workflows/reusable_publish_python.yml
+++ b/.github/workflows/reusable_publish_python.yml
@@ -15,14 +15,14 @@ jobs:
       id-token: write
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_PUBLISH_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
 
       - name: Run CodeBuild
-        uses: aws-actions/aws-codebuild-run-build@v1
+        uses: aws-actions/aws-codebuild-run-build@7e46c3fa1c1f217e26a73712796b1f78938b534b # v1.0.18
         with:
           project-name: ${{ github.event.repository.name }}-release-Publish
           hide-cloudwatch-logs: true

--- a/.github/workflows/reusable_publish_v2.yml
+++ b/.github/workflows/reusable_publish_v2.yml
@@ -27,7 +27,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
@@ -67,14 +67,14 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
           token: ${{ secrets.CI_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.9'
 
@@ -123,7 +123,7 @@ jobs:
           tag: ${{ env.TAG }}
 
       - name: UploadArtifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: build-artifact
           path: |
@@ -166,17 +166,17 @@ jobs:
       TAG: ${{needs.PreRelease.outputs.tag}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{env.TAG}}
           fetch-depth: 0
           token: ${{ secrets.CI_TOKEN }}
 
       - name: Download
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_PGP_KEY_SECRET_ROLE }}
           aws-region: us-west-2
@@ -228,13 +228,13 @@ jobs:
         os: ${{ fromJson(inputs.installer_oses) }}    
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_INSTALLER_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
       - name: Run CodeBuild
-        uses: aws-actions/aws-codebuild-run-build@v1
+        uses: aws-actions/aws-codebuild-run-build@7e46c3fa1c1f217e26a73712796b1f78938b534b # v1.0.18
         with:
           project-name: ReleaseInstallerProject
           hide-cloudwatch-logs: true
@@ -258,14 +258,14 @@ jobs:
       TAG: ${{needs.PreRelease.outputs.tag}}
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_RELEASE_PUBLISH_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
 
       - name: Run CodeBuild
-        uses: aws-actions/aws-codebuild-run-build@v1
+        uses: aws-actions/aws-codebuild-run-build@7e46c3fa1c1f217e26a73712796b1f78938b534b # v1.0.18
         with:
           project-name: ${{ github.event.repository.name }}-release-Publish
           hide-cloudwatch-logs: true
@@ -289,20 +289,20 @@ jobs:
       TAG: ${{needs.PreRelease.outputs.tag}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{env.TAG}}
           fetch-depth: 0
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.9'
 
@@ -312,7 +312,7 @@ jobs:
           pip install --upgrade twine
 
       - name: Download
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
 
       - name: Publish to Repository
         run: |

--- a/.github/workflows/reusable_python_build.yml
+++ b/.github/workflows/reusable_python_build.yml
@@ -36,21 +36,21 @@ jobs:
       PY_COLORS: 1
       HATCH_DATA_DIR: ${{ github.workspace }}/.hatch-data
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       if: ${{ !inputs.branch && !inputs.commit && !inputs.ref }}
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       if: ${{ inputs.branch }}
       with:
         ref: ${{ inputs.branch }}
         fetch-depth: 0
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       if: ${{ inputs.commit }}
       with:
         ref: ${{ inputs.commit }}
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       if: ${{ inputs.ref }}
       with:
         ref: ${{ inputs.ref }}
@@ -66,13 +66,13 @@ jobs:
 
     - name: Set up Python ${{ inputs.python-version }}
       id: setup-python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
         python-version: ${{ inputs.python-version }}
         cache: pip
 
     - name: Restore Hatch environment cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ github.workspace }}/.hatch-data/env
         # Include the full patch version so the cache busts when the runner image

--- a/.github/workflows/reusable_record_pr_details.yml
+++ b/.github/workflows/reusable_record_pr_details.yml
@@ -24,7 +24,7 @@ jobs:
           echo "$PR_ACTION" > ./pr-info/pr-action.txt
       
       - name: Upload PR info artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: pr-info
           path: ./pr-info/

--- a/.github/workflows/reusable_release.yml
+++ b/.github/workflows/reusable_release.yml
@@ -18,22 +18,22 @@ jobs:
     environment: release
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{inputs.tag}}
           fetch-depth: 0
           token: ${{ secrets.CI_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.9'
 
       - name: Download
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_PGP_KEY_SECRET_ROLE }}
           aws-region: us-west-2

--- a/.github/workflows/reusable_release_installers.yml
+++ b/.github/workflows/reusable_release_installers.yml
@@ -22,13 +22,13 @@ jobs:
         os: ${{ fromJson(inputs.oses) }}    
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_CODEBUILD_MAINLINE_INSTALLER_ROLE }}
           aws-region: us-west-2
           mask-aws-account-id: true
       - name: Run CodeBuild
-        uses: aws-actions/aws-codebuild-run-build@v1
+        uses: aws-actions/aws-codebuild-run-build@7e46c3fa1c1f217e26a73712796b1f78938b534b # v1.0.18
         with:
           project-name: ReleaseInstallerProject
           hide-cloudwatch-logs: true

--- a/.github/workflows/reusable_security_scan.yml
+++ b/.github/workflows/reusable_security_scan.yml
@@ -1,0 +1,53 @@
+# Reusable security-scan umbrella workflow.
+#
+# This is the single, central place where repo-agnostic security checks live.
+# Repos call it from a thin stub (see security_scan.yml in each repo), so new
+# checks can be added here as additional jobs WITHOUT having to edit every repo.
+#
+# Current checks:
+#   - zizmor: static analysis of GitHub Actions workflows (https://zizmor.sh)
+#
+# To add a future check: add a new job below, optionally gated behind a new
+# `workflow_call` input (defaulting to enabled), and it will apply everywhere
+# the stub is present on the next run.
+name: "Security Scan"
+
+on:
+  workflow_call:
+    inputs:
+      zizmor:
+        description: "Run the zizmor GitHub Actions static analysis check."
+        required: false
+        type: boolean
+        default: true
+      fail-on-findings:
+        description: >-
+          Fail the check when findings are present. Defaults to false so the
+          scan is advisory (findings still upload to the Security tab) while the
+          existing backlog is burned down; flip to true per-repo once findings
+          reach zero.
+        required: false
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor (GitHub Actions)
+    if: ${{ inputs.zizmor }}
+    runs-on: ubuntu-latest
+    permissions:
+      # Required for zizmor-action to upload SARIF results to the Security tab.
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        # While advisory, don't fail the check on findings — SARIF is still
+        # uploaded to the Security tab so results stay visible.
+        continue-on-error: ${{ !inputs.fail-on-findings }}
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2

--- a/.github/workflows/reusable_security_scan.yml
+++ b/.github/workflows/reusable_security_scan.yml
@@ -46,8 +46,24 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Fetch central zizmor config
+        # The zizmor.yml policy lives once in aws-deadline/.github and is shared
+        # by every repo, so a single edit there updates policy fleet-wide.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: aws-deadline/.github
+          ref: mainline
+          path: .zizmor-config
+          persist-credentials: false
+
       - name: Run zizmor 🌈
         # While advisory, don't fail the check on findings — SARIF is still
         # uploaded to the Security tab so results stay visible.
         continue-on-error: ${{ !inputs.fail-on-findings }}
         uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        with:
+          # Scope to .github/ so the nested central-config checkout at
+          # .zizmor-config/ is not itself scanned. All workflows and composite
+          # actions live under .github/, so coverage is complete.
+          inputs: .github/
+          config: .zizmor-config/zizmor.yml

--- a/.github/workflows/reusable_stale_prs_and_issues.yml
+++ b/.github/workflows/reusable_stale_prs_and_issues.yml
@@ -11,7 +11,7 @@ jobs:
   stale-review-stage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           debug-only: false
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable_tag_release.yml
+++ b/.github/workflows/reusable_tag_release.yml
@@ -24,7 +24,7 @@ jobs:
       tag: ${{ steps.tag-release.outputs.tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.tag || github.sha }}
           fetch-depth: 0

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,19 @@
+# Central zizmor configuration for all aws-deadline repos.
+#
+# This file lives once in aws-deadline/.github and is consumed by the reusable
+# Security Scan workflow (reusable_security_scan.yml), which passes it to zizmor
+# via --config when scanning each member repo. Editing it here changes policy
+# for every repo on the next run — no per-repo change needed.
+#
+# Docs: https://docs.zizmor.sh/configuration/
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # Our own reusable workflows and composite actions are referenced by
+        # branch (e.g. @mainline) on purpose: a single central bump then
+        # propagates to every consuming repo. Allow a ref (branch/tag) pin here.
+        aws-deadline/*: ref-pin
+        # Everything third-party MUST be pinned to a full commit SHA. Dependabot
+        # (see .github/dependabot.yml) proposes SHA bumps to keep these current.
+        "*": hash-pin


### PR DESCRIPTION
## What

Adds `reusable_security_scan.yml` — a central, **extensible** security-scan umbrella workflow that member repos invoke from a thin stub.

- **zizmor** (GitHub Actions static analysis, https://zizmor.sh) is the first check.
- Designed so future checks are added here as sibling jobs — member repos never need re-editing to pick them up.
- Actions are SHA-pinned, matching the existing `botocore`/`s3transfer` zizmor setup.

## Rollout posture

zizmor runs **advisory** by default (`fail-on-findings: false` → `continue-on-error`) so it does not turn every PR red against the current findings backlog. SARIF still uploads to the **Security** tab, so results stay visible. Each repo flips `fail-on-findings: true` once its findings reach zero.

## Why here vs per-repo

Member repos already delegate CI to this org repo's reusable workflows (e.g. `reusable_python_build.yml`, `reusable_codeql.yml`). Putting the logic here keeps the zizmor version/config centrally managed; the companion PR adds the calling stub to `deadline-cloud`, which is then copied to the rest of the fleet.

Companion PR: stub in `aws-deadline/deadline-cloud`.

## Findings preview (offline `zizmor` run, current state)

| Repo | High | Medium |
|---|---|---|
| deadline-cloud | 91 | 45 |
| .github (reusable workflows) | 88 | 23 |
| deadline-cloud-job-attachments | 48 | 19 |
| deadline-cloud-worker-agent | 35 | 18 |

Dominated by `unpinned-uses` (tags not SHAs), plus real `template-injection` (`github.base_ref` into `run:` blocks) and `dangerous-triggers` (`workflow_run`). Many are auto-fixable in follow-ups.

🤖 Draft — not published for review yet.